### PR TITLE
Improve tablet layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,9 @@ body{
 }
 
 @media (max-width:900px){
-  .boardWrap{ max-width: 100%; }
+  body{ grid-template-columns:1fr; }
+  .boardWrap{ max-width:100%; }
+  .panel{ position:static; }
 }
 
 /* ======= PANEL FIJO (del 200.html) ======= */


### PR DESCRIPTION
## Summary
- stack panel below board on narrow viewports for better tablet support
- make panel non-sticky and fit full width on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bcd14f10483249141425b3612d634