### PR TITLE
Adjust tile font sizes for tablets

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,12 @@ dialog .row input{ margin-left:6px; width:120px }
 .tile .badges{ display:flex; gap:4px; align-items:center; justify-content:center; }
 .tile .badge{ font-size:.65rem; border:1px solid #64748b; border-radius:6px; padding:1px 6px; background:#0b1220 }
 
+@media (max-width:1024px){
+  .tile .name{ font-size:clamp(.45rem,1.2vw,.6rem); }
+  .tile .meta{ font-size:clamp(.4rem,1vw,.55rem); }
+  .tile .badge{ font-size:clamp(.35rem,.9vw,.5rem); }
+}
+
 /* Fichas */
 .chips{ position:absolute; left:6px; bottom:6px; display:flex; gap:3px; }
 .chip{ width:18px; height:18px; border-radius:50%; border:2px solid #fff; display:flex; align-items:center; justify-content:center; font-size:.7rem; font-weight:900; color:#fff; filter:drop-shadow(0 1px 4px rgba(255,255,255,.25)); }


### PR DESCRIPTION
## Summary
- reduce tile text size on tablets with responsive CSS media query

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_689bd0b95e0883249df22cb74bd3a489