### PR TITLE
Fix property card display on tile click

### DIFF
--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -30,11 +30,12 @@ function createTileElement(tile, index){
   meta.appendChild(left); meta.appendChild(right);
 
   el.addEventListener('click', ()=>{
-  if (tile && typeof window.showCard === 'function'){
-    // Permitir iniciar subasta desde el click, si la propiedad está libre.
-    window.showCard(index); // por defecto canAuction=false
-  }
-});
+    const current = V13.tiles[index];
+    if (current && typeof window.showCard === 'function'){
+      // Permitir iniciar subasta desde el click, si la propiedad está libre.
+      window.showCard(index); // por defecto canAuction=false
+    }
+  });
 
   el.appendChild(band); el.appendChild(head); el.appendChild(idTag); el.appendChild(badges); el.appendChild(meta);
   return el;


### PR DESCRIPTION
## Summary
- Ensure tile click handlers use current board data when showing property cards

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd12cd5688324aa969a7924405b46