### PR TITLE
Add corrupt bank tiles evenly across board

### DIFF
--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -3,7 +3,7 @@
 const V13_COLORS = {
   brown:'#8b5a2b', cyan:'#22d3ee', pink:'#f472b6', orange:'#fb923c',
   red:'#ef4444', yellow:'#eab308', green:'#22c55e', blue:'#3b82f6', slots:'#d946ef',
-  event:'#a855f7', util:'#64748b', rail:'#94a3b8', ferry:'#60a5fa', air:'#0ea5e9',
+  bank:'#b91c1c', event:'#a855f7', util:'#64748b', rail:'#94a3b8', ferry:'#60a5fa', air:'#0ea5e9',
   start:'#10b981', tax:'#f59e0b', park:'#22c55e', gotojail:'#ef4444', jail:'#111827'
 };
 function colorFor(tile){ if(!tile) return '#475569'; const k=(tile.color||tile.subtype||tile.type||'').toLowerCase(); return V13_COLORS[k]||'#475569'; }
@@ -56,6 +56,7 @@ function refreshTile(i){
   else if (t.type==='jail') left.textContent='Solo visitas';
   else if (t.type==='gotojail') left.textContent='Ir a la cárcel';
   else if (t.type==='slots') left.textContent='Tragaperras';
+  else if (t.type==='bank') left.textContent='Banca corrupta';
   else if (t.type==='park') left.textContent='Parque';
   else if (t.type==='event'){ left.textContent='Evento'; }
   else left.textContent='';

--- a/js/v20-part3.js
+++ b/js/v20-part3.js
@@ -283,6 +283,19 @@ window.TILES = TILES;
   TILES.splice(pos2, 0, { type:'slots', name:'Tragape 2' });
 })();
 
+// === Casillas especiales: Banca corrupta x4 equidistantes ===
+(function(){
+  const count = 4;
+  const finalLen = TILES.length + count;
+  const step = Math.floor(finalLen / count);
+  const positions = [];
+  for(let i=0;i<count;i++){
+    positions.push(Math.floor(step/2) + i*step);
+  }
+  positions.forEach(pos=> TILES.splice(pos, 0, { type:'bank', name:'Banca corrupta' }));
+  window.CORRUPT_BANK_TILE_IDS = positions;
+})();
+
 /* ===== Nombres placeholder (por si dejas alguno vacío) ===== */
 window.assignPlaceholderNamesAZ = function(){
   const isNormal = x => x && x.type==='prop' && !x.subtype;

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -150,9 +150,9 @@ Estado.money = 0;
   if (window.Roles) {
     Roles.assign(state.players.map(p => ({ id: p.id, name: p.name })));
 
-    // Activa banca corrupta y registra las 3 casillas (pon tus IDs)
+    // Activa banca corrupta y registra casillas equidistantes
     Roles.setBankCorrupt(true);
-    Roles.registerCorruptBankTiles([12, 28, 42]);
+    Roles.registerCorruptBankTiles(window.CORRUPT_BANK_TILE_IDS || []);
 
     // Farmazixe con fentanilo (pon IDs de las farmacias)
     Roles.configureFentanyl({ tileIds: [62, 63], chance: 0.15, fee: 15 });


### PR DESCRIPTION
## Summary
- add support and styling for corrupt bank tiles
- insert four evenly spaced corrupt bank tiles and expose their indices
- register corrupt bank tiles during new game setup

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "global.window=global; global.document={getElementById:()=>({}), addEventListener:()=>{}}; global.addEventListener=()=>{}; global.dispatchEvent=()=>{}; require('./js/v20-part3.js'); console.log(window.CORRUPT_BANK_TILE_IDS); console.log(window.TILES.length);"`


------
https://chatgpt.com/codex/tasks/task_e_689bd235de48832498a3c942c358c038