### PR TITLE
Adjust iPad styles to shrink font and keep sidebar sticky

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,12 @@ body.playing .setup { justify-content:flex-end; gap:8px; }
   .panel{ position:static }
 }
 
+/* ajustes para iPad */
+@media only screen and (min-device-width:768px) and (max-device-width:1024px){
+  html{ font-size:25%; }
+  .panel{ position:sticky; top:12px; }
+}
+
 /* Hipotecada → borde dorado */
 .tile.mortgaged{
   border-color:#f59e0b !important;


### PR DESCRIPTION
## Summary
- Reduce default font sizing to 25% on iPad screens
- Ensure sidebar remains sticky on iPad layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd35229488324adb9a6483c8200e5