### PR TITLE
Increase player money display for iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@ button.primary{ background:#22c55e; border-color:#16a34a; color:#06280f; }
 
 .players{ display:flex; gap:6px; flex-wrap:wrap; }
 .badge{ padding:6px 10px; border-radius:999px; border:1px solid var(--border); font-size:.92rem; }
+.players .badge{ display:flex; align-items:center; gap:6px; }
+.badge .money{ font-size:6em; line-height:1; }
 .badge.active{ outline:2px solid #22c55e; }
 #players{ margin-bottom:10px }
 

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -93,14 +93,14 @@ function renderPlayers(){
     b.className = 'badge player' + (p.id===state.current ? ' active' : '');
     const color = COLORS[p.id % COLORS.length];
     b.style.borderColor = color;
-    b.innerHTML = `<span class="dot" style="background:${color}"></span>${p.name}: ${fmtMoney(p.money)}${p.alive?'':' (OUT)'}`;
+    b.innerHTML = `<span class="dot" style="background:${color}"></span>${p.name}: <span class="money">${fmtMoney(p.money)}</span>${p.alive?'':' (OUT)'}`;
     wrap.appendChild(b);
   });
 
   // Estado (banca) al final
   const e = document.createElement('div');
   e.className = 'badge state';
-  e.textContent = `Estado: ${fmtMoney(Estado.money||0)}`;
+  e.innerHTML = `Estado: <span class="money">${fmtMoney(Estado.money||0)}</span>`;
   wrap.appendChild(e);
 
   // visible solo cuando hay partida


### PR DESCRIPTION
## Summary
- Enlarge player money text for better visibility on iPad
- Show state and player balances in enlarged format

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd6766b4083249d55959529ea7503