### PR TITLE
fix: cerrar carta de propiedad al pulsar fuera

### DIFF
--- a/js/v20-part3.js
+++ b/js/v20-part3.js
@@ -373,6 +373,16 @@ const cardRent = document.getElementById('cardRent');
 const cardRoi  = document.getElementById('cardRoi');
 if (cardRoi && cardRoi.parentElement) cardRoi.parentElement.style.display = 'none';
 
+// Permitir cerrar la carta clicando fuera del contenido
+if (overlay){
+  overlay.addEventListener('click', (ev)=>{
+    if (ev.target === overlay){
+      overlay.style.display = 'none';
+      if (window.state) window.state.pendingTile = null;
+    }
+  });
+}
+
 const rentsBox = document.getElementById('cardRentsBox');
 const bankWarn = document.getElementById('bankWarn');
 const startAuctionBtn = document.getElementById('startAuction');


### PR DESCRIPTION
## Summary
- Permite cerrar el modal de propiedad haciendo clic en el fondo

## Testing
- `node --check js/v20-part3.js`


------
https://chatgpt.com/codex/tasks/task_e_689bd6d224708324bb8fdda68ac1e767