### PR TITLE
Enable role editing and event triggers in debug mode

### DIFF
--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -824,6 +824,14 @@ Aceptar=A, Cancelar=B') ? 'A' : 'B';
   R.setEstadoAuctionBlocked = function(flag){ state.estadoAuctionBlocked = !!flag; saveState(); uiUpdate(); };
   R.isEstadoAuctionBlocked = function(){ return !!state.estadoAuctionBlocked; };
   R.listAssignments = function(){ return (state.players||[]).map(p=>({ id:p.id, name:p.name, role: roleOf(p.id) })); };
+  R.setRole = function(playerId, role){
+    var id = (playerId&&playerId.id)||playerId;
+    setRole(id, normalizeRoleGuess(role));
+    ensureFlorentinoUses();
+    saveState();
+    uiUpdate();
+  };
+  R.ROLES = Object.assign({}, ROLE);
 
   // === Eventos/CARTAS unificados ===
 // Llamas con el nombre que uses en tu mazo o en tus triggers de casilla.


### PR DESCRIPTION
## Summary
- Add `Roles.setRole` export and role constants for editing
- Enhance debug panel with editable roles and new Events tab to trigger events or teleport to tiles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/v22_roles_politics.js` *(fails: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689bdcf50d78832498a3d37696f3f3cc