### PR TITLE
Fix oversized money display on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,10 @@ button.primary{ background:#22c55e; border-color:#16a34a; color:#06280f; }
 .players{ display:flex; gap:6px; flex-wrap:wrap; }
 .badge{ padding:6px 10px; border-radius:999px; border:1px solid var(--border); font-size:.92rem; }
 .players .badge{ display:flex; align-items:center; gap:6px; }
-.badge .money{ font-size:6em; line-height:1; }
+.badge .money{ font-size:1em; line-height:1; }
+@media (max-width:900px){
+  .badge .money{ font-size:6em; }
+}
 .badge.active{ outline:2px solid #22c55e; }
 #players{ margin-bottom:10px }
 


### PR DESCRIPTION
## Summary
- reduce player money badge font size on desktop to match other controls
- keep enlarged money display only on small screens via media query

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bddad18bc8324a398d3fdd81506c6