### PR TITLE
Add strict mode directives to v20 JS parts

### DIFF
--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* v13 – Parte 2/7: motor de UI (tablero + casillas visibles tipo v11) */
 
 const V13_COLORS = {

--- a/js/v20-part3.js
+++ b/js/v20-part3.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const COLORS = {
   brown:'#78350f', cyan:'#06b6d4', pink:'#db2777', orange:'#f97316',
   red:'#ef4444', yellow:'#eab308', green:'#22c55e', blue:'#3b82f6',

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* v13 – Parte 4/7 (patched): setup, panel jugadores, utilidades de dinero
    — Esta versión mantiene TODA la economía y turnos aquí (fuente de verdad).
    — Muestra también el Estado (banca) al final del panel.

--- a/js/v20-part5.js
+++ b/js/v20-part5.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* v13 – Parte 5/7: dados, movimiento, SALIDA, turnos */
 
 function addSkipTurn(player, turns = 1) {

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* v13 – Parte 6/7: efectos al caer y sistema de subastas */
 
 // === [PATCH] Ajuste de alquileres con eventos ===

--- a/js/v20-part7.js
+++ b/js/v20-part7.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* v13 – Parte 7/7 (patched): construir, vender, hipoteca, préstamos
    — Sólo acciones del propietario + utilidades (applyTax, sendToJail).
    — NO redefine ni transfer, ni renderPlayers, ni newGame (eso queda en part4).


### PR DESCRIPTION
## Summary
- Ensure `v20-part2` through `v20-part7` scripts run in strict mode by adding `'use strict';` at the top of each file.

## Testing
- `for f in js/v20-part2.js js/v20-part3.js js/v20-part4.js js/v20-part5.js js/v20-part6.js js/v20-part7.js; do node --check $f && echo "$f OK"; done`

------
https://chatgpt.com/codex/tasks/task_e_689bddd87acc8324b935b52b7191d7fa