### PR TITLE
Refactor prompts in v20-part6.js with custom dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,6 +223,18 @@ body.playing .setup { justify-content:flex-end; gap:8px; }
     </form>
   </dialog>
 
+  <!-- diálogo genérico para solicitudes de entrada -->
+  <dialog id="promptDialog">
+    <form method="dialog" id="promptForm">
+      <p id="promptMessage"></p>
+      <input id="promptInput" type="text">
+      <div class="row" style="margin-top:8px; justify-content:flex-end">
+        <button type="button" id="promptCancel">Cancelar</button>
+        <button type="submit" class="primary">Aceptar</button>
+      </div>
+    </form>
+  </dialog>
+
   <!-- jugadores -->
   <div class="players" id="players"></div>
 


### PR DESCRIPTION
## Summary
- Replace `var` declarations with `let`/`const` in v20-part6.js
- Implement reusable `<dialog>` based prompt and migrate existing prompts
- Wire up async handlers for transport hops and casino roulette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bdde438c883248e46795d01a0cdc0