### PR TITLE
Add basic JavaScript tests with Node's test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -74,3 +74,12 @@ Conceptos de economía y finanzas aplicados a juegos (subastas, préstamos, secu
 Opcional: introducir herramientas modernas (bundlers, tests) si se busca mantenimiento a largo plazo.
 
 Con esta visión, un nuevo integrante puede orientarse rápidamente en el código y decidir qué parte estudiar o extender según sus intereses.
+
+Ejecución de pruebas
+--------------------
+Se han añadido tests básicos empleando el *test runner* integrado en Node.js. Para ejecutarlos, asegúrate de tener Node >= 18 y después ejecuta:
+
+```
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "artiako-landak-alpha-2",
+  "version": "1.0.0",
+  "description": "Aplicación web Artiako Landak",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test tests"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/colorFor.test.js
+++ b/tests/colorFor.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+global.window = {};
+global.document = { addEventListener: () => {} };
+
+require('../js/v20-part2.js');
+const { colorFor } = global.window.BoardUI;
+
+test('colorFor devuelve gris por defecto cuando falta color', () => {
+  assert.strictEqual(colorFor({}), '#475569');
+});
+
+test('colorFor devuelve el color correcto para casillas rojas', () => {
+  assert.strictEqual(colorFor({ color: 'red' }), '#ef4444');
+});


### PR DESCRIPTION
## Summary
- Configure Node's built-in test runner via npm script
- Add sample tests covering board color logic
- Document test execution in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bde15be448324abfd823743773840