### PR TITLE
fix: show board tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="boardWrap">
-  <div class="board" id="board" class="dark"></div>
+  <div id="board" class="board dark"></div>
 </div>
 
 <!-- ===== PANEL nuevo (manteniendo IDs del v15) ===== -->


### PR DESCRIPTION
## Summary
- restore `.board` class on game board element so tiles render properly

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689be88a38188324bfab560955d4a493