### PR TITLE
Fix ITV prompt newline to restore board rendering

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -6318,8 +6318,7 @@ if (typeof window.transfer === 'function'){
     const id = (playerId&&playerId.id)||playerId;
     let c = choice;
     if(!c && typeof window!=='undefined'){
-      c = window.confirm('¿ITV sin pasar? A: irte al monte (pierdes turno). B: ayudar (cárcel para ti y el de la izquierda).
-Aceptar=A, Cancelar=B') ? 'A' : 'B';
+      c = window.confirm('¿ITV sin pasar? A: irte al monte (pierdes turno). B: ayudar (cárcel para ti y el de la izquierda).\nAceptar=A, Cancelar=B') ? 'A' : 'B';
     }
     if(c==='A'){
       queueSkip(id, 1);

--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -633,8 +633,7 @@
     const id = (playerId&&playerId.id)||playerId;
     let c = choice;
     if(!c && typeof window!=='undefined'){
-      c = window.confirm('¿ITV sin pasar? A: irte al monte (pierdes turno). B: ayudar (cárcel para ti y el de la izquierda).
-Aceptar=A, Cancelar=B') ? 'A' : 'B';
+      c = window.confirm('¿ITV sin pasar? A: irte al monte (pierdes turno). B: ayudar (cárcel para ti y el de la izquierda).\nAceptar=A, Cancelar=B') ? 'A' : 'B';
     }
     if(c==='A'){
       queueSkip(id, 1);


### PR DESCRIPTION
## Summary
- Fix syntax error in `card_ITV` confirmation dialog by replacing literal newline with `\n`
- Rebuild `dist/bundle.js` to include corrected prompt

## Testing
- `node build.js`
- `npm test` *(fails: Missing script: "test")*
- `node tests/colorFor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689bea8c7c0c832481eab72ef7c66204