### PR TITLE
Enable debt market and securitization options on corrupt bank tile

### DIFF
--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -83,9 +83,13 @@ async function onLand(p, idx){
     const cbt = st && st.corruptBankTiles || [];
     if (Array.isArray(cbt) && cbt.indexOf(idx) !== -1) {
       const opt = await promptDialog(
-        'Banca corrupta:\n1) Préstamo corrupto\n2) Securitizar alquileres (' +
-        (Roles && RolesConfig ? (RolesConfig.securiTicks||3) : 3) + ' ticks, anticipo ' +
-        (Roles && RolesConfig ? (RolesConfig.securiAdvance||150) : 150) + ')\n(Enter = nada)',
+        'Banca corrupta:\n'
+        + '1) Préstamo corrupto\n'
+        + '2) Securitizar alquileres ('
+        + (Roles && RolesConfig ? (RolesConfig.securiTicks||3) : 3) + ' ticks, anticipo '
+        + (Roles && RolesConfig ? (RolesConfig.securiAdvance||150) : 150)
+        + ')\n3) Mercado deuda (GameDebtMarket)\n'
+        + '4) Titulización de préstamo\n(Enter = nada)',
         ''
       );
       if (opt === '1') {
@@ -106,6 +110,37 @@ async function onLand(p, idx){
           // anticipo al jugador y a partir de ahora sus alquileres van al Estado por S.ticks
           transfer(Estado, getPlayerById(p.id), S.advance, { taxable:false, reason:'Securitización corrupta' });
           log('Securitización: cobras ' + S.advance + ' ahora; durante ' + S.ticks + ' ticks tus alquileres van al Estado.');
+        }
+      } else if (opt === '3') {
+        const principal = Number(await promptDialog('Principal préstamo deuda:', '300'))||0;
+        const rate = Number(await promptDialog('Tipo (%):', '20'))||0;
+        const term = Number(await promptDialog('Plazo (turnos):', '12'))||0;
+        const L = GameDebtMarket.mkLoan({
+          borrowerId: p.id,
+          lenderId: 'E',
+          principal,
+          ratePct: rate,
+          termTurns: term
+        });
+        GameDebtMarket.addLoan(L);
+        transfer(Estado, getPlayerById(p.id), principal, { taxable:false, reason:'Préstamo mercado deuda' });
+        log('Mercado deuda: préstamo ' + L.id + ' creado.');
+      } else if (opt === '4') {
+        const loanId = await promptDialog('ID préstamo a titulizar:', '');
+        if (loanId) {
+          try {
+            const shares = GameSecuritization.splitLoan(loanId, [
+              { ownerId: p.id, bips: 5000 },
+              { ownerId: 'E', bips: 5000 }
+            ]);
+            if (shares) {
+              log('Titulización OK: ' + shares.join(','));
+            } else {
+              alert('No se pudo titulizar');
+            }
+          } catch (e) {
+            alert('Error titulizando: ' + e.message);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add new choices when landing on a corrupt bank tile for accessing the debt market and advanced securitization.
- Integrate GameDebtMarket loan creation and GameSecuritization loan splitting as corrupt bank actions.

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689be95d4aac8324a3318506a19ff033