### PR TITLE
feat: support human and bot players

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,11 @@
         <button id="cancelSetup" type="button">Cancelar</button>
       </div>
       <div class="setup row" style="margin:.5rem 0">
-        <label>Jugadores:
-          <input id="numPlayers" type="number" min="2" max="6" value="3">
+        <label>Humanos:
+          <input id="numHumans" type="number" min="0" max="6" value="2">
+        </label>
+        <label>Bots:
+          <input id="numBots" type="number" min="0" max="6" value="1">
         </label>
         <label>Dinero inicial:
           <input id="startMoney" type="number" min="100" step="50" value="500">

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -193,13 +193,22 @@ function renderDice(d1, d2, meta=''){
 /* ===== Nueva partida ===== */
 function newGame(){
 Estado.money = 0;
-  const n = Math.max(2, Math.min(6, parseInt($('#numPlayers').value||'3',10)));
+  let humans = Math.max(0, Math.min(6, parseInt($('#numHumans').value||'2',10)));
+  let bots   = Math.max(0, Math.min(6, parseInt($('#numBots').value||'1',10)));
+  let total  = humans + bots;
+  if (total < 2){ bots = Math.max(0, 2 - humans); total = humans + bots; }
+  if (total > 6){ bots = Math.max(0, 6 - humans); total = humans + bots; }
   const startMoney = Math.max(100, parseInt($('#startMoney').value||'500',10));
 
-  state.players = Array.from({length:n},(_,i)=>({
-    id:i, name:`J${i+1}`, money:startMoney, pos:0, alive:true,
-    jail:0, taxBase:0, doubleStreak:0
-  }));
+  state.players = [];
+  for (let i=0;i<humans;i++){
+    state.players.push({ id: state.players.length, name:`J${i+1}`, money:startMoney, pos:0, alive:true,
+      jail:0, taxBase:0, doubleStreak:0 });
+  }
+  for (let i=0;i<bots;i++){
+    state.players.push({ id: state.players.length, name:`Bot${i+1}`, money:startMoney, pos:0, alive:true,
+      jail:0, taxBase:0, doubleStreak:0, isBot:true });
+  }
 
   // v22: roles y casillas especiales
   if (window.Roles) {
@@ -239,6 +248,7 @@ Estado.money = 0;
   $('#log').innerHTML = '';
   log('Nueva partida creada.');
   updateTurnButtons();
+  if (state.players[state.current]?.isBot) botAutoPlay?.();
   document.body.classList.add('playing');   // <- esto debe estar
   renderPlayers(); // asegúrate de llamarlo después de setear el estado
 }

--- a/js/v20-part5.js
+++ b/js/v20-part5.js
@@ -17,6 +17,15 @@ function nextAlive(from){
   return from;
 }
 
+function botAutoPlay(){
+  const p = state.players[state.current];
+  if (!p?.isBot) return;
+  setTimeout(()=>{
+    if (!state.rolled) roll();
+    setTimeout(()=>{ if (state.rolled) endTurn(); }, 900);
+  }, 600);
+}
+
 function movePlayer(p, steps){
   if(!p.alive) return;
   const total = TILES.length;
@@ -276,6 +285,7 @@ function endTurn() {
 
     renderPlayers();
     log(`— Turno de ${state.players[state.current].name} —`);
+    botAutoPlay();
 
     // [PATCH] Hooks de inicio de turno para módulos
     try {


### PR DESCRIPTION
## Summary
- allow choosing human and bot counts at game setup
- initialize bots with isBot flag and auto-play their turns
- rebuild bundle

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689beb0d1318832490e522ff43271238