### PR TITLE
Fix board not showing after new game

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1041,6 +1041,8 @@ Estado.money = 0;
 
   if (typeof applySavedPropNames === 'function') applySavedPropNames(); // ← aquí
 
+  document.body.classList.add('playing');   // <- esto debe estar
+
   BoardUI.attach({ tiles:TILES, state });
   BoardUI.renderBoard();
   renderPlayers();
@@ -1048,7 +1050,6 @@ Estado.money = 0;
   log('Nueva partida creada.');
   updateTurnButtons();
   if (state.players[state.current]?.isBot) botAutoPlay?.();
-  document.body.classList.add('playing');   // <- esto debe estar
   renderPlayers(); // asegúrate de llamarlo después de setear el estado
 }
 document.addEventListener('DOMContentLoaded', ()=>{

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -241,6 +241,7 @@ Estado.money = 0;
   if (typeof window.randomizeSpecials === 'function') window.randomizeSpecials();
 
   if (typeof applySavedPropNames === 'function') applySavedPropNames(); // ← aquí
+  document.body.classList.add('playing');   // <- esto debe estar
 
   BoardUI.attach({ tiles:TILES, state });
   BoardUI.renderBoard();
@@ -249,7 +250,6 @@ Estado.money = 0;
   log('Nueva partida creada.');
   updateTurnButtons();
   if (state.players[state.current]?.isBot) botAutoPlay?.();
-  document.body.classList.add('playing');   // <- esto debe estar
   renderPlayers(); // asegúrate de llamarlo después de setear el estado
 }
 document.addEventListener('DOMContentLoaded', ()=>{


### PR DESCRIPTION
## Summary
- Ensure the `playing` class is added before re-rendering the board and players so they display correctly when starting a new game.

## Testing
- `node --test tests/colorFor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689becf9c00c8324924f67e6b887f208