### PR TITLE
Fix roles script placeholder and speed up event overlay

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -5272,19 +5272,29 @@ if (typeof window.transfer === 'function'){
     `;
     document.head.appendChild(css);
   })();
-  function showEventCard(title, text){
-    return new Promise((resolve)=>{
-      const ov = document.getElementById('doubleOverlay');
-      if (!ov) return resolve(); // fallback si no hay overlay
-      ov.innerHTML = `<div class="eventCard">
-        <div class="eventTitle">${title||'SUERTE'}</div>
-        <div class="eventText">${text||''}</div>
-        <button class="eventBtn" autofocus>Aceptar</button>
-      </div>`;
-      ov.style.display = 'flex';
-      ov.querySelector('.eventBtn').onclick = ()=>{ ov.style.display='none'; resolve(); };
-    });
-  }
+    function showEventCard(title, text){
+      return new Promise((resolve)=>{
+        const ov = document.getElementById('doubleOverlay');
+        if (!ov) return resolve(); // fallback si no hay overlay
+        ov.innerHTML = `<div class="eventCard">
+          <div class="eventTitle">${title||'SUERTE'}</div>
+          <div class="eventText">${text||''}</div>
+          <button class="eventBtn" autofocus>Aceptar</button>
+        </div>`;
+        ov.style.display = 'flex';
+        ov.style.opacity = '1';
+        ov.style.transition = 'opacity 0.2s';
+        let closed = false;
+        function close(){
+          if(closed) return;
+          closed = true;
+          ov.style.opacity = '0';
+          setTimeout(()=>{ ov.style.display='none'; ov.style.opacity=''; resolve(); }, 200);
+        }
+        ov.querySelector('.eventBtn').onclick = close;
+        setTimeout(close, 700);
+      });
+    }
 
   // Mapa de descripciones (nombre → desc)
   const EVENT_DESCS = {
@@ -6394,7 +6404,7 @@ if (typeof window.transfer === 'function'){
     }
   };
 
-  document.addEventListener('DOMContentLoaded', ()=>{ $1
+  document.addEventListener('DOMContentLoaded', ()=>{
     // listener simple para toggle de panel de roles
     try {
       window.addEventListener('roles:toggle', function(){

--- a/js/v20-part8.js
+++ b/js/v20-part8.js
@@ -251,19 +251,29 @@
     `;
     document.head.appendChild(css);
   })();
-  function showEventCard(title, text){
-    return new Promise((resolve)=>{
-      const ov = document.getElementById('doubleOverlay');
-      if (!ov) return resolve(); // fallback si no hay overlay
-      ov.innerHTML = `<div class="eventCard">
-        <div class="eventTitle">${title||'SUERTE'}</div>
-        <div class="eventText">${text||''}</div>
-        <button class="eventBtn" autofocus>Aceptar</button>
-      </div>`;
-      ov.style.display = 'flex';
-      ov.querySelector('.eventBtn').onclick = ()=>{ ov.style.display='none'; resolve(); };
-    });
-  }
+    function showEventCard(title, text){
+      return new Promise((resolve)=>{
+        const ov = document.getElementById('doubleOverlay');
+        if (!ov) return resolve(); // fallback si no hay overlay
+        ov.innerHTML = `<div class="eventCard">
+          <div class="eventTitle">${title||'SUERTE'}</div>
+          <div class="eventText">${text||''}</div>
+          <button class="eventBtn" autofocus>Aceptar</button>
+        </div>`;
+        ov.style.display = 'flex';
+        ov.style.opacity = '1';
+        ov.style.transition = 'opacity 0.2s';
+        let closed = false;
+        function close(){
+          if(closed) return;
+          closed = true;
+          ov.style.opacity = '0';
+          setTimeout(()=>{ ov.style.display='none'; ov.style.opacity=''; resolve(); }, 200);
+        }
+        ov.querySelector('.eventBtn').onclick = close;
+        setTimeout(close, 700);
+      });
+    }
 
   // Mapa de descripciones (nombre → desc)
   const EVENT_DESCS = {

--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -648,7 +648,7 @@
     }
   };
 
-  document.addEventListener('DOMContentLoaded', ()=>{ $1
+  document.addEventListener('DOMContentLoaded', ()=>{
     // listener simple para toggle de panel de roles
     try {
       window.addEventListener('roles:toggle', function(){


### PR DESCRIPTION
## Summary
- Remove stray placeholder in roles module causing `$1 is not defined` error
- Auto-dismiss event overlay with quick fade to ease selecting tiles

## Testing
- `node build.js`
- `node tests/colorFor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689bf102d77c83249bd5df8ba1c7e71d