### PR TITLE
Unify roles banner with debug panel

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -6255,6 +6255,7 @@ if (typeof window.transfer === 'function'){
   function uiLog(msg){ try{ console.log('[Roles]', msg); }catch(e){} }
 
   function renderBanner(){
+    if (window.__V20_DEBUG_INSTALLED__) { if (bannerEl) bannerEl.remove(); return; }
     if(!document || !document.body) return;
     if(!bannerEl){
       bannerEl = document.createElement('div');
@@ -6394,7 +6395,8 @@ if (typeof window.transfer === 'function'){
     }
   };
 
-  document.addEventListener('DOMContentLoaded', ()=>{ $1
+  document.addEventListener('DOMContentLoaded', ()=>{
+    if (window.__V20_DEBUG_INSTALLED__) return;
     // listener simple para toggle de panel de roles
     try {
       window.addEventListener('roles:toggle', function(){
@@ -6809,6 +6811,8 @@ R.eventsList = [
   const logBox = el('div'); logBox.style.cssText='margin-top:8px;border:1px solid #eee;background:#fff;color:#111;border-radius:8px;padding:6px;min-height:140px;white-space:pre-wrap';
 
   // Roles tab content
+  const rolesStatus = el('div');
+  rolesStatus.style.cssText='margin-top:8px;font-size:12px;color:#111';
   const rolesBox = el('div');
   rolesBox.style.cssText='margin-top:8px;border:1px solid #eee;background:#fff;color:#111;border-radius:8px;padding:6px;min-height:120px';
   const rolesActions = el('div');
@@ -6819,6 +6823,7 @@ R.eventsList = [
   btnBankCorrupt.style.cssText='padding:4px 8px;border:1px solid #ddd;background:#ffe;border-radius:8px;cursor:pointer;color:#111';
   rolesActions.appendChild(btnEstadoBid);
   rolesActions.appendChild(btnBankCorrupt);
+  secRoles.appendChild(rolesStatus);
   secRoles.appendChild(rolesBox);
   secRoles.appendChild(rolesActions);
 
@@ -6836,6 +6841,15 @@ R.eventsList = [
 
   function renderRoles(){
     try{
+      const st = window.state || {};
+      const gov = st.government ? (st.government==='left'?'Izquierda':'Derecha') : '—';
+      const turns = st.government ? (st.governmentTurnsLeft||0) : 0;
+      const taxPot = st.taxPot || 0;
+      const loans = (st.loans||[]).length;
+      const blocked = window.Roles?.isEstadoAuctionBlocked ? !!Roles.isEstadoAuctionBlocked() : !!st.estadoAuctionBlocked;
+      const corrupt = window.Roles?.isBankCorrupt ? !!Roles.isBankCorrupt() : !!st.bankCorrupt;
+      rolesStatus.textContent = `Gobierno: ${gov} (${turns}) · Banca corrupta: ${corrupt?'ON':'OFF'} · Bote impuestos: ${taxPot} · Préstamos: ${loans} · Estado puja: ${blocked?'OFF':'ON'}`;
+
       if (!window.Roles){
         rolesBox.textContent = 'Roles no cargado.';
         btnEstadoBid.disabled = true;

--- a/js/v20-debug.js
+++ b/js/v20-debug.js
@@ -81,6 +81,8 @@
   const logBox = el('div'); logBox.style.cssText='margin-top:8px;border:1px solid #eee;background:#fff;color:#111;border-radius:8px;padding:6px;min-height:140px;white-space:pre-wrap';
 
   // Roles tab content
+  const rolesStatus = el('div');
+  rolesStatus.style.cssText='margin-top:8px;font-size:12px;color:#111';
   const rolesBox = el('div');
   rolesBox.style.cssText='margin-top:8px;border:1px solid #eee;background:#fff;color:#111;border-radius:8px;padding:6px;min-height:120px';
   const rolesActions = el('div');
@@ -91,6 +93,7 @@
   btnBankCorrupt.style.cssText='padding:4px 8px;border:1px solid #ddd;background:#ffe;border-radius:8px;cursor:pointer;color:#111';
   rolesActions.appendChild(btnEstadoBid);
   rolesActions.appendChild(btnBankCorrupt);
+  secRoles.appendChild(rolesStatus);
   secRoles.appendChild(rolesBox);
   secRoles.appendChild(rolesActions);
 
@@ -108,6 +111,15 @@
 
   function renderRoles(){
     try{
+      const st = window.state || {};
+      const gov = st.government ? (st.government==='left'?'Izquierda':'Derecha') : '—';
+      const turns = st.government ? (st.governmentTurnsLeft||0) : 0;
+      const taxPot = st.taxPot || 0;
+      const loans = (st.loans||[]).length;
+      const blocked = window.Roles?.isEstadoAuctionBlocked ? !!Roles.isEstadoAuctionBlocked() : !!st.estadoAuctionBlocked;
+      const corrupt = window.Roles?.isBankCorrupt ? !!Roles.isBankCorrupt() : !!st.bankCorrupt;
+      rolesStatus.textContent = `Gobierno: ${gov} (${turns}) · Banca corrupta: ${corrupt?'ON':'OFF'} · Bote impuestos: ${taxPot} · Préstamos: ${loans} · Estado puja: ${blocked?'OFF':'ON'}`;
+
       if (!window.Roles){
         rolesBox.textContent = 'Roles no cargado.';
         btnEstadoBid.disabled = true;

--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -509,6 +509,7 @@
   function uiLog(msg){ try{ console.log('[Roles]', msg); }catch(e){} }
 
   function renderBanner(){
+    if (window.__V20_DEBUG_INSTALLED__) { if (bannerEl) bannerEl.remove(); return; }
     if(!document || !document.body) return;
     if(!bannerEl){
       bannerEl = document.createElement('div');
@@ -648,7 +649,8 @@
     }
   };
 
-  document.addEventListener('DOMContentLoaded', ()=>{ $1
+  document.addEventListener('DOMContentLoaded', ()=>{
+    if (window.__V20_DEBUG_INSTALLED__) return;
     // listener simple para toggle de panel de roles
     try {
       window.addEventListener('roles:toggle', function(){


### PR DESCRIPTION
## Summary
- add status summary to debug panel Roles tab
- disable separate roles banner and debug panel when primary debug overlay is present

## Testing
- `node build.js`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689bf2129254832491a1e4654329795f