### PR TITLE
Keep debug panel open during role selection

### DIFF
--- a/js/v20-debug.js
+++ b/js/v20-debug.js
@@ -285,6 +285,9 @@
 
   // Keyboard toggle
   document.addEventListener('keydown', (ev)=>{
+    if (ev.repeat) return;
+    const tag = ev.target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || ev.target.isContentEditable) return;
     if ((ev.key==='d' || ev.key==='D') && !ev.altKey && !ev.metaKey && !ev.ctrlKey){
       toggleBtn.click(); ev.preventDefault();
     }


### PR DESCRIPTION
## Summary
- Prevent debug panel from toggling when typing inside inputs or selects
- Ignore repeated 'D' key presses so panel doesn't close immediately

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bf5bfb2088324b75efa84973e3dd7