### PR TITLE
Compact auction bidding layout

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -2075,7 +2075,6 @@ function drawAuction(){
       ${players.map(p=>`
         <div class="auctionPlayer ${(!sealed && a.bestPlayer===p.id) ? 'leader' : ''}" data-p="${p.id}">
           <div class="name">${p.name}</div>
-          <div class="money">${fmtMoney(p.money)}</div>
           <div class="controls">
             <button data-act="bid" data-step="10" data-p="${p.id}">+10</button>
             <button data-act="bid" data-step="50" data-p="${p.id}">+50</button>
@@ -7027,6 +7026,9 @@ R.eventsList = [
 
   // Keyboard toggle
   document.addEventListener('keydown', (ev)=>{
+    if (ev.repeat) return;
+    const tag = ev.target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || ev.target.isContentEditable) return;
     if ((ev.key==='d' || ev.key==='D') && !ev.altKey && !ev.metaKey && !ev.ctrlKey){
       toggleBtn.click(); ev.preventDefault();
     }

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -535,7 +535,6 @@ function drawAuction(){
       ${players.map(p=>`
         <div class="auctionPlayer ${(!sealed && a.bestPlayer===p.id) ? 'leader' : ''}" data-p="${p.id}">
           <div class="name">${p.name}</div>
-          <div class="money">${fmtMoney(p.money)}</div>
           <div class="controls">
             <button data-act="bid" data-step="10" data-p="${p.id}">+10</button>
             <button data-act="bid" data-step="50" data-p="${p.id}">+50</button>

--- a/styles.css
+++ b/styles.css
@@ -70,12 +70,12 @@ button.primary{ background:#22c55e; border-color:#16a34a; color:#06280f; }
   gap:12px;
 }
 .auctionHeader h3{ margin:0; font-size:1.1rem; }
-.auctionPlayers{ display:flex; flex-direction:column; gap:10px; }
-.auctionPlayer{ border:1px solid var(--border); border-radius:8px; padding:8px; }
+.auctionPlayers{ display:flex; flex-direction:column; gap:4px; }
+.auctionPlayer{ border:1px solid var(--border); border-radius:8px; padding:4px 8px; display:flex; align-items:center; gap:6px; }
 .auctionPlayer.leader{ border-color:#f59e0b; box-shadow:0 0 6px rgba(245,158,11,.6); }
 .auctionPlayer .name{ font-weight:600; }
-.auctionPlayer .money{ font-size:.9rem; opacity:.85; }
-.auctionPlayer .controls{ margin-top:6px; display:flex; flex-wrap:wrap; gap:4px; }
+.auctionPlayer .controls{ margin-top:0; display:flex; flex-wrap:nowrap; gap:4px; }
+.auctionPlayer .controls button{ padding:2px 6px; font-size:.8rem; }
 .auctionActions{ display:flex; justify-content:flex-end; }
 .log{ background:#0d1117; border:1px solid #30363d; border-radius:12px; padding:10px; min-height:160px; max-height:380px; overflow:auto; font-family:ui-monospace,monospace; font-size:.9rem }
 


### PR DESCRIPTION
## Summary
- Display each auction participant on a single line with bid and pass controls
- Shrink auction buttons for a tighter layout
- Rebuild bundle

## Testing
- `node build.js`
- `node tests/colorFor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689bfa92619483248347d71b49c58426