### PR TITLE
Start new games without bots by default

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -999,7 +999,7 @@ function renderDice(d1, d2, meta=''){
 function newGame(){
 Estado.money = 0;
   let humans = Math.max(0, Math.min(6, parseInt($('#numHumans').value||'2',10)));
-  let bots   = Math.max(0, Math.min(6, parseInt($('#numBots').value||'1',10)));
+  let bots   = Math.max(0, Math.min(6, parseInt($('#numBots').value||'0',10)));
   let total  = humans + bots;
   if (total < 2){ bots = Math.max(0, 2 - humans); total = humans + bots; }
   if (total > 6){ bots = Math.max(0, 6 - humans); total = humans + bots; }
@@ -7027,6 +7027,9 @@ R.eventsList = [
 
   // Keyboard toggle
   document.addEventListener('keydown', (ev)=>{
+    if (ev.repeat) return;
+    const tag = ev.target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || ev.target.isContentEditable) return;
     if ((ev.key==='d' || ev.key==='D') && !ev.altKey && !ev.metaKey && !ev.ctrlKey){
       toggleBtn.click(); ev.preventDefault();
     }

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
           <input id="numHumans" type="number" min="0" max="6" value="2">
         </label>
         <label>Bots:
-          <input id="numBots" type="number" min="0" max="6" value="1">
+          <input id="numBots" type="number" min="0" max="6" value="0">
         </label>
         <label>Dinero inicial:
           <input id="startMoney" type="number" min="100" step="50" value="500">

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -194,7 +194,7 @@ function renderDice(d1, d2, meta=''){
 function newGame(){
 Estado.money = 0;
   let humans = Math.max(0, Math.min(6, parseInt($('#numHumans').value||'2',10)));
-  let bots   = Math.max(0, Math.min(6, parseInt($('#numBots').value||'1',10)));
+  let bots   = Math.max(0, Math.min(6, parseInt($('#numBots').value||'0',10)));
   let total  = humans + bots;
   if (total < 2){ bots = Math.max(0, 2 - humans); total = humans + bots; }
   if (total > 6){ bots = Math.max(0, 6 - humans); total = humans + bots; }


### PR DESCRIPTION
## Summary
- Default bots input to 0 so new games start without bots
- Ensure game setup code uses 0 bots when no value provided
- Regenerate bundle to include new default

## Testing
- `node --test tests/colorFor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689bfafd68288324bf2e74ae1ae81e66