### PR TITLE
Enable debug teleport to corrupt bank tiles

### DIFF
--- a/js/v20-debug.js
+++ b/js/v20-debug.js
@@ -160,7 +160,7 @@
   function teleportTo(subtype){
     try{
       const T = window.TILES || [];
-      const idx = T.findIndex(t=>t.subtype===subtype);
+      const idx = T.findIndex(t=>t.subtype===subtype || t.type===subtype);
       const p = window.state?.players?.[window.state?.current];
       if(idx>=0 && p){
         p.pos = idx;
@@ -189,7 +189,7 @@
       const label2 = el('div',{textContent:'Ir a casilla:'});
       label2.style.marginTop = '8px';
       const sel2 = el('select');
-      ['casino_bj','casino_roulette','fiore','bus','rail','ferry','air'].forEach(st=> sel2.appendChild(el('option',{value:st,textContent:st})));
+      ['casino_bj','casino_roulette','fiore','bus','rail','ferry','air','bank'].forEach(st=> sel2.appendChild(el('option',{value:st,textContent:st})));
       const btn2 = el('button',{textContent:'Ir'});
       btn2.style.cssText='margin-left:6px';
       btn2.onclick=()=>{ teleportTo(sel2.value); };


### PR DESCRIPTION
## Summary
- let teleport action find tiles by type, covering corrupt bank
- add 'bank' option to debug event teleport list

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689c01195be08324a225b355682ee76b