### PR TITLE
fix: initialize board bindings after DOM ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ document.querySelector('.controls button:last-child')?.addEventListener('click',
   const r=document.querySelector('.rules'); if(r) r.open=!r.open;
 });
 
-document.addEventListener('DOMContentLoaded', ()=>{
+function initGameBindings(){
   // [PATCH] Inicialización de módulos
   if (window.GameDebtMarket) {
     GameDebtMarket.install({ state: window.state, fixPropertyAuction: true });
@@ -204,7 +204,10 @@ document.addEventListener('DOMContentLoaded', ()=>{
       window.showCard(idx);
     }
   });
-});
+}
+
+if (document.readyState !== 'loading') initGameBindings();
+else document.addEventListener('DOMContentLoaded', initGameBindings);
 </script>
 <script>
 (()=>{


### PR DESCRIPTION
## Summary
- Ensure board click events and module installation run even when DOMContentLoaded has already fired

## Testing
- `node tests/colorFor.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c0db6db748324ad0a803c9483b89a