### PR TITLE
Improve debug events tab usability

### DIFF
--- a/js/v20-debug.js
+++ b/js/v20-debug.js
@@ -581,13 +581,16 @@
   }
 
   // Periodic refresh when panel open
+  // Slow down the refresh and avoid rerendering events while focused
   setInterval(()=>{
     if (DBG.enabled){
       render();
       if (secRoles.style.display === 'block') renderRoles();
-      if (secEvents.style.display === 'block') renderEvents();
+      if (secEvents.style.display === 'block' && !eventsBox.contains(document.activeElement)){
+        renderEvents();
+      }
     }
-  }, 500);
+  }, 1000);
 
   // Start open if env says so
   document.addEventListener('DOMContentLoaded', ()=>{


### PR DESCRIPTION
## Summary
- Slow events tab refresh to 1s and skip rerender when interacting

## Testing
- `npm test` *(fails: Missing script)*
- `node --test` *(fails: Expected values to be strictly equal / roles absent)*

------
https://chatgpt.com/codex/tasks/task_e_689c75a1ded88324b0817ff81033d4ef