### PR TITLE
Enable judge challenges on auction awards

### DIFF
--- a/js/auction+debt-market-v21.js
+++ b/js/auction+debt-market-v21.js
@@ -113,6 +113,23 @@
       a.open = false;
 
       if (a.bestPlayer && a.bestBid > 0) {
+        // Impugnación por un tercero antes de adjudicar
+        try {
+          const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
+          if (who) {
+            const byId = Number(who) - 1;
+            const base = Math.max(1, a.price || 1);
+            const imbalance = Math.max(0, Math.min(1, (base - a.bestBid) / base));
+            const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
+            if (res.annulled) {
+              alert('⚖️ Juez IA anula la adjudicación.');
+              state.auction = null;
+              this._closeAuctionOverlay();
+              return;
+            }
+          }
+        } catch {}
+
         if (a.kind === 'tile') {
           this._assignTileTo(a.assetId, a.bestPlayer, a.bestBid);
         } else if (a.kind === 'loan') {

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -686,6 +686,26 @@ function awardAuction(){
     price    = bestV;
   }
 
+  // Impugnación por un tercero antes de adjudicar
+  try {
+    const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
+    if (who) {
+      const byId = Number(who) - 1;
+      const base = Math.max(1, t.price || 1);
+      const imbalance = Math.max(0, Math.min(1, (base - price) / base));
+      const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
+      if (res.annulled) {
+        alert('⚖️ Juez IA anula la adjudicación.');
+        $('#auction').style.display = 'none';
+        state.auction = null;
+        const endTurnBtn = document.getElementById('endTurn');
+        if (endTurnBtn) endTurnBtn.disabled = false;
+        updateTurnButtons();
+        return;
+      }
+    }
+  } catch {}
+
   // Ganó Estado
   if (winnerId==='E'){
     if ((Estado.money||0) < price){

--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -142,7 +142,16 @@
     state.taxPot = 0;
     state.fbiAllKnownReady = false;
 
-
+    // Número de roles especiales a asignar según probabilidad
+    const total = state.players.length;
+    const n = Math.floor(total * (cfg.roleProbability || 0));
+    const rolesPool = [ROLE.PROXENETA, ROLE.FLORENTINO, ROLE.FBI];
+    const rolesToAssign = rolesPool.slice(0, n);
+    const shuffled = state.players.slice().sort(()=> Math.random() - 0.5);
+    rolesToAssign.forEach((role, idx)=>{
+      const p = shuffled[idx];
+      if (p) state.assignments.set(p.id, role);
+    });
 
     ensureFlorentinoUses();
     saveState();


### PR DESCRIPTION
## Summary
- allow third-party challenges before adjudicating property auctions
- support challenge mechanism in debt-market auctions
- implement basic probabilistic role assignment

## Testing
- `node build.js`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689c770e4ca08324af97787ab3958f8a