### PR TITLE
Enable 0-9 dice and improve tile visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
   window.RolesConfig = Object.assign({}, window.RolesConfig||{}, {
     roleProbability: 0.20,
     bankMaxTicks: 30,
-    dice0to9: false
+    dice0to9: true
   });
 </script>
 <!-- JS bundle -->

--- a/styles.css
+++ b/styles.css
@@ -87,14 +87,14 @@ dialog .row input{ margin-left:6px; width:120px }
 .tile .badge{ font-size:.58rem; }
 
 /* Casilla tipo v11 */
-.tile{
-  position:absolute;
-  width:var(--tileW); height:var(--tileH);
-  background:linear-gradient(180deg,#111827,#0b1220);
-  border:2px solid #475569; border-radius:10px;
-  display:grid; grid-template-rows:auto 1fr auto; gap:4px;
-  padding:6px; transition:transform .12s,box-shadow .12s;
-}
+  .tile{
+    position:absolute;
+    width:var(--tileW); height:var(--tileH);
+    background:linear-gradient(180deg,#1e293b,#0f172a);
+    border:2px solid #94a3b8; border-radius:10px;
+    display:grid; grid-template-rows:auto 1fr auto; gap:4px;
+    padding:6px; transition:transform .12s,box-shadow .12s;
+  }
 .tile:hover{ transform:translateY(-3px); box-shadow:0 0 8px rgba(255,255,255,.15); }
 .tile .band{ height:8px; border-radius:6px; box-shadow:inset 0 -1px 0 rgba(0,0,0,.35); }
 .tile .head{ display:flex; justify-content:center; align-items:center; gap:6px; }


### PR DESCRIPTION
## Summary
- Always use 0-9 dice range via RolesConfig
- Lighten tile background and border so board squares are visible

## Testing
- `node tests/colorFor.test.js`
- `node tests/rolesUnique.test.js` *(fails: expected 20% role assignment but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_689c88e158e8832495c8a2a0238ae135