### PR TITLE
Fix board init timing and improve tile interactivity

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -223,12 +223,14 @@ window.BoardUI = {
 };
 
 /* ==== Auto-init ==== */
-document.addEventListener('DOMContentLoaded', ()=>{
+function autoInit(){
   const tiles = window.TILES || [];
   const state = window.state || null;
   window.BoardUI.attach({ tiles, state });
   if (tiles.length){ window.BoardUI.renderBoard(); }
-});
+}
+if (document.readyState !== 'loading') autoInit();
+else document.addEventListener('DOMContentLoaded', autoInit);
 'use strict';
 
 const COLORS = {

--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -223,9 +223,12 @@ window.BoardUI = {
 };
 
 /* ==== Auto-init ==== */
-document.addEventListener('DOMContentLoaded', ()=>{
+function autoInit(){
   const tiles = window.TILES || [];
   const state = window.state || null;
   window.BoardUI.attach({ tiles, state });
   if (tiles.length){ window.BoardUI.renderBoard(); }
-});
+}
+
+if (document.readyState !== 'loading') autoInit();
+else document.addEventListener('DOMContentLoaded', autoInit);

--- a/styles.css
+++ b/styles.css
@@ -93,7 +93,7 @@ dialog .row input{ margin-left:6px; width:120px }
     background:linear-gradient(180deg,#1e293b,#0f172a);
     border:2px solid #94a3b8; border-radius:10px;
     display:grid; grid-template-rows:auto 1fr auto; gap:4px;
-    padding:6px; transition:transform .12s,box-shadow .12s;
+    padding:6px; transition:transform .12s,box-shadow .12s; cursor:pointer;
   }
 .tile:hover{ transform:translateY(-3px); box-shadow:0 0 8px rgba(255,255,255,.15); }
 .tile .band{ height:8px; border-radius:6px; box-shadow:inset 0 -1px 0 rgba(0,0,0,.35); }


### PR DESCRIPTION
## Summary
- Initialize board immediately when the document is already loaded, preventing a missing board
- Apply the same immediate initialization in the bundled script
- Mark tiles with a pointer cursor to clarify they are clickable

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_689c8ebb57708324a7124f086384ec6a