### PR TITLE
Add scarcity pricing and money printer event

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -4407,25 +4407,48 @@ function buildHouse(){
   const costNoIVA = Math.max(1, Math.round(baseCost * (state.buildEventMul||1)));   // sin IVA
   const finalCost = Math.max(1, Math.round(costNoIVA * (state.buildIVAMul||1)));    // con IVA
   const ivaPart   = Math.max(0, finalCost - costNoIVA);
+  const gov = window.Roles?.getGovernment?.();
+  let mult = 1;
+  let buildHotel = false;
   if (t.hotel){ log('Ya tiene hotel.'); return; }
-  if (p.money < finalCost){ log('No te llega el dinero para construir.'); return; }
 
   if (t.houses < 4) {
-    if (BANK.housesAvail <= 0) { alert('No hay casas disponibles en el banco.'); return; }
-    BANK.housesAvail--;
-    t.houses++;
+    if (BANK.housesAvail <= 0) {
+      if (gov === 'right') {
+        mult = 4;
+      } else {
+        alert('No hay casas disponibles en el banco.'); return;
+      }
+    }
   } else {
     if (!canBuildHotel(t,p)) { log('Para hotel: todas las del grupo con 4 casas.'); return; }
-    if (BANK.hotelsAvail <= 0) { alert('No hay hoteles disponibles en el banco.'); return; }
-    BANK.hotelsAvail--;
+    if (BANK.hotelsAvail <= 0) {
+      if (gov === 'right') {
+        mult = 4;
+      } else {
+        alert('No hay hoteles disponibles en el banco.'); return;
+      }
+    }
+    buildHotel = true;
+  }
+
+  const totalCost = finalCost * mult;
+  const ivaTotal  = ivaPart * mult;
+  if (p.money < totalCost){ log('No te llega el dinero para construir.'); return; }
+
+  if (!buildHotel) {
+    if (BANK.housesAvail > 0) BANK.housesAvail--;
+    t.houses++;
+  } else {
+    if (BANK.hotelsAvail > 0) BANK.hotelsAvail--;
     BANK.housesAvail += 4; // se devuelven al banco
     t.hotel = true; t.houses = 0;
   }
 
   // El jugador paga el coste total (con IVA) al Estado.
-  transfer(p, Estado, finalCost, {taxable:false, reason:`Construcción en ${t.name}`});
+  transfer(p, Estado, totalCost, {taxable:false, reason:`Construcción en ${t.name}`});
   // La parte del IVA se marca como "soportado" para la futura liquidación.
-  if (ivaPart > 0) markIVAPaid(p, ivaPart, ' (construcción)');
+  if (ivaTotal > 0) markIVAPaid(p, ivaTotal, ' (construcción)');
   log(`🏠 Construido en ${t.name}.`);
   BoardUI.refreshTiles(); renderPlayers();
 }
@@ -6357,6 +6380,10 @@ if (typeof window.transfer === 'function'){
   R.tickTurn = function(){
     state.turnCounter++;
     state.noRentFromWomen.clear();
+    if(['left','right','authoritarian'].includes(state.government) && rand.chance(1/200)){
+      if(typeof log === 'function') log('money printer go brrrrrrrr'); else uiLog('money printer go brrrrrrrr');
+      if(typeof Estado === 'object') Estado.money = (Estado.money||0) + 800;
+    }
     if(state.turnCounter % 60 === 0 && rand.chance(0.10)){
       const tipo = rand.pick(['Terremoto','Tornado','Huracán']);
       const bank = (typeof BANK === 'object') ? BANK : null;

--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -364,6 +364,10 @@
   R.tickTurn = function(){
     state.turnCounter++;
     state.noRentFromWomen.clear();
+    if(['left','right','authoritarian'].includes(state.government) && rand.chance(1/200)){
+      if(typeof log === 'function') log('money printer go brrrrrrrr'); else uiLog('money printer go brrrrrrrr');
+      if(typeof Estado === 'object') Estado.money = (Estado.money||0) + 800;
+    }
     if(state.turnCounter % 60 === 0 && rand.chance(0.10)){
       const tipo = rand.pick(['Terremoto','Tornado','Huracán']);
       const bank = (typeof BANK === 'object') ? BANK : null;


### PR DESCRIPTION
## Summary
- Allow house or hotel construction at 4x cost when right-wing government and stock is depleted
- Introduce 1/200 chance each turn for left, right, or authoritarian governments to print 800 coins and log "money printer go brrrrrrrr"

## Testing
- `node build.js`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689ccf3873788324b3605c60a1b628eb