### PR TITLE
Fix corrupt bank menu and tile info overlay

### DIFF
--- a/js/v20-part3.js
+++ b/js/v20-part3.js
@@ -427,18 +427,35 @@ function showCard(tileIndex, {canAuction=false}={}) {
   const t = TILES[tileIndex];
   const st = window.state;
   if (st) st.pendingTile = tileIndex;
+  // Título por defecto
+  if (cardBand) {
+    cardBand.textContent = t?.name || '';
+    cardBand.onclick = null;
+  }
 
+  // Ocultar secciones específicas inicialmente
+  if (cardPriceRow) cardPriceRow.style.display = 'none';
+  if (cardRentRow)  cardRentRow.style.display  = 'none';
+  if (cardBuildRow) cardBuildRow.style.display = 'none';
+  if (startAuctionBtn) startAuctionBtn.style.display = 'none';
+
+  rentsBox.innerHTML = '';
+  bankWarn.className = 'muted';
+  bankWarn.textContent = FUNNY[t.type] || FUNNY.default;
 
   if (t.type === 'prop') {
-    cardBand.onclick = ()=>{
-      const nuevo = prompt('Nuevo nombre de la propiedad:', t.name||'');
-      if (nuevo && nuevo.trim()){
-        t.name = nuevo.trim();
-        savePropName(tileIndex, t.name);
-        cardBand.textContent = t.name;
-        BoardUI.refreshTile(tileIndex);
-      }
-    };
+    if (cardBand) {
+      cardBand.textContent = t.name;
+      cardBand.onclick = ()=>{
+        const nuevo = prompt('Nuevo nombre de la propiedad:', t.name||'');
+        if (nuevo && nuevo.trim()){
+          t.name = nuevo.trim();
+          savePropName(tileIndex, t.name);
+          cardBand.textContent = t.name;
+          BoardUI.refreshTile(tileIndex);
+        }
+      };
+    }
 
     // vehículos y utilities: ocultar “Renta base”, pero mostrar tabla
     const isVehicleOrUtil = ['rail','bus','ferry','air','utility'].includes(t.subtype);
@@ -459,11 +476,7 @@ function showCard(tileIndex, {canAuction=false}={}) {
       if (cardBuild) cardBuild.textContent = `Casa ${fmtMoney(cost)} · Hotel ${fmtMoney(cost)}`;
     }
 
-
-    const msg = FUNNY[t.type] || FUNNY.default;
-    bankWarn.className = 'muted';
-    bankWarn.textContent = msg;
-    rentsBox.innerHTML = '';
+    if (startAuctionBtn) startAuctionBtn.style.display = canAuction ? '' : 'none';
   }
   overlay.style.display = 'flex';
 }

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -100,10 +100,8 @@ async function onLand(p, idx){
   if (window.UIX?.track.onLand) UIX.track.onLand(idx);
 
   // Si es una casilla de banca corrupta: menú rápido
-  try {
-    const st = Roles.exportState ? Roles.exportState() : null;
-    const cbt = st && st.corruptBankTiles || [];
-    if (Array.isArray(cbt) && cbt.indexOf(idx) !== -1) {
+  if (t.type === 'bank') {
+    try {
       const opt = await promptDialog(
         'Banca corrupta:\n'
         + '1) Préstamo corrupto\n'
@@ -165,8 +163,8 @@ async function onLand(p, idx){
           }
         }
       }
-    }
-  } catch(e){}
+    } catch(e){}
+  }
 
   switch(t.type){
     case 'start':


### PR DESCRIPTION
## Summary
- Show card information for any tile and hide property-only details when not needed
- Trigger corrupt bank actions whenever a player lands on a bank tile

## Testing
- `node tests/colorFor.test.js`
- `node tests/rolesUnique.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689cd1073f488324aaa9789bbc1d233f