### PR TITLE
Restringe impugnaciones a intercambios de propiedades

### DIFF
--- a/js/auction+debt-market-v21.js
+++ b/js/auction+debt-market-v21.js
@@ -113,23 +113,6 @@
       a.open = false;
 
       if (a.bestPlayer && a.bestBid > 0) {
-        // Impugnación por un tercero antes de adjudicar
-        try {
-          const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-          if (who) {
-            const byId = Number(who) - 1;
-            const base = Math.max(1, a.price || 1);
-            const imbalance = Math.max(0, Math.min(1, (base - a.bestBid) / base));
-            const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-            if (res.annulled) {
-              alert('⚖️ Juez IA anula la adjudicación.');
-              state.auction = null;
-              this._closeAuctionOverlay();
-              return;
-            }
-          }
-        } catch {}
-
         if (a.kind === 'tile') {
           this._assignTileTo(a.assetId, a.bestPlayer, a.bestBid);
         } else if (a.kind === 'loan') {

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -710,26 +710,6 @@ function awardAuction(){
     price    = bestV;
   }
 
-  // Impugnación por un tercero antes de adjudicar
-  try {
-    const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-    if (who) {
-      const byId = Number(who) - 1;
-      const base = Math.max(1, t.price || 1);
-      const imbalance = Math.max(0, Math.min(1, (base - price) / base));
-      const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-      if (res.annulled) {
-        alert('⚖️ Juez IA anula la adjudicación.');
-        $('#auction').style.display = 'none';
-        state.auction = null;
-        const endTurnBtn = document.getElementById('endTurn');
-        if (endTurnBtn) endTurnBtn.disabled = false;
-        updateTurnButtons();
-        return;
-      }
-    }
-  } catch {}
-
   // Ganó Estado
   if (winnerId==='E'){
     if ((Estado.money||0) < price){

--- a/js/v20-part7.js
+++ b/js/v20-part7.js
@@ -570,15 +570,21 @@ async function trade(){
         }
       }
 
-      // Impugnación por un tercero antes de ejecutar el trato
-      const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-      if (who) {
-        const byId = Number(who)-1;
-        // desbalance (0..1) según ganancia neta
-        const denom   = Math.max(1, Math.abs(myGain)+Math.abs(otGain));
-        const imbalance = Math.min(1, Math.abs(myGain-otGain)/denom);
-        const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled:false };
-        if (res.annulled) { alert('⚖️ Juez IA anula el trato.'); return; }
+      // Impugnación por jugadores no implicados en el trato
+      const challengers = state.players.filter(p => p && p.alive && p.id !== me.id && p.id !== other.id);
+      if (challengers.length > 0) {
+        const ids = challengers.map(p => p.id + 1).join(',');
+        const who = prompt(`Impugnación de (${ids})… (ID de jugador) o vacío para seguir`, '');
+        if (who) {
+          const byId = Number(who) - 1;
+          if (challengers.some(p => p.id === byId)) {
+            // desbalance (0..1) según ganancia neta
+            const denom = Math.max(1, Math.abs(myGain) + Math.abs(otGain));
+            const imbalance = Math.min(1, Math.abs(myGain - otGain) / denom);
+            const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled:false };
+            if (res.annulled) { alert('⚖️ Juez IA anula el trato.'); return; }
+          }
+        }
       }
 
   if (give>0 && me.money<give){ alert('No tienes suficiente dinero.'); return; }


### PR DESCRIPTION
## Summary
- Elimina la posibilidad de impugnar durante subastas
- Permite impugnaciones solo a terceros fuera del intercambio de propiedades
- Reconstruye el bundle con los cambios

## Testing
- `node tests/colorFor.test.js`
- `node tests/rolesUnique.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689cd416bb2483249adc37235dab9638