### PR TITLE
Ensure onLand function asynchronous

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1711,6 +1711,7 @@ function isEstadoCovered(tile){
   return false;
 }
 
+// Must be async so we can await user interactions when landing on tiles
 async function onLand(p, idx){
   const getPlayerById = (id) => (id === 'E' || id === Estado) ? Estado : state.players[id];
   const t = TILES[idx];


### PR DESCRIPTION
## Summary
- document and ensure the `onLand` handler is declared as `async` so awaits in tile landing logic work

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cddc94ca48324858084c1d2b2fb1f