### PR TITLE
feat: add utility modules and deterministic RNG integration

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,12 @@ const fs = require('fs');
 const path = require('path');
 
 const files = [
+  'js/utils/core.js',
+  'js/utils/rng.js',
+  'js/utils/state_sanitize.js',
+  'js/utils/tx.js',
+  'js/utils/fuzz.js',
+  'js/utils/watchdog.js',
   'js/v20-part2.js',
   'js/v20-part3.js',
   'js/v20-part4.js',

--- a/js/utils/core.js
+++ b/js/utils/core.js
@@ -1,0 +1,34 @@
+(function(global){
+  const assert = (cond, msg='Assert failed') => { if (!cond) throw new Error(msg); };
+
+  const clamp = (x, min, max) => Math.min(max, Math.max(min, x));
+
+  let _lock = false;
+  async function nonReentrant(fn){
+    if (_lock) throw new Error('Reentrancy');
+    _lock = true;
+    try { return await fn(); } finally { _lock = false; }
+  }
+
+  const toCents = (n) => (n==null?0:Math.round(Number(n)*100));
+  const fromCents = (c) => (c|0)/100;
+  const money = {
+    add:(a,b)=>a+b,
+    sub:(a,b)=>a-b,
+    mul:(a,k)=>Math.round(a*k),
+    div:(a,k)=>Math.round(a/k)
+  };
+
+  function makeLogger(cap=500){
+    const buf = new Array(cap); let i=0, full=false;
+    return {
+      log:(...xs)=>{ buf[i]=[Date.now(), ...xs]; i=(i+1)%cap; if(i===0) full=true; },
+      dump:()=> full ? buf.slice(i).concat(buf.slice(0,i)) : buf.slice(0,i),
+      clear:()=>{ i=0; full=false; }
+    };
+  }
+
+  const api = { assert, clamp, nonReentrant, toCents, fromCents, money, makeLogger };
+  global.utils = Object.assign(global.utils || {}, api);
+  if (typeof module !== 'undefined') module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/js/utils/fuzz.js
+++ b/js/utils/fuzz.js
@@ -1,0 +1,25 @@
+(function(global){
+  const { makeRNG } = global.utils || {};
+  const { validateState } = global.utils || {};
+
+  function runFuzz({ state, TILES, turns=200, seed=12345, actPerTurn=3, actions }){
+    const rng = makeRNG ? makeRNG(seed) : null; const errors=[];
+    for (let t=0; t<turns; t++){
+      for (let k=0;k<actPerTurn;k++){
+        const a = rng ? rng.pick(actions) : actions[Math.floor(Math.random()*actions.length)];
+        try { a(state, TILES, rng); } catch(e){ errors.push({turn:t, action:a.name||'anon', error:e.message}); }
+        const errs = validateState ? validateState(state, TILES) : [];
+        if (errs.length) errors.push({turn:t, action:a.name||'anon', errs});
+      }
+    }
+    return errors;
+  }
+  const sampleActions = [
+    function moveRand(s,T,rng){ const p = s.players[rng.int(0,s.players.length-1)]; p.pos = (p.pos + rng.int(1,6)) % T.length; },
+    function payRent(s,T,rng){ const p = s.players[rng.int(0,s.players.length-1)]; p.money -= rng.int(10,200); }
+  ];
+
+  const api = { runFuzz, sampleActions };
+  global.utils = Object.assign(global.utils || {}, api);
+  if (typeof module !== 'undefined') module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/js/utils/rng.js
+++ b/js/utils/rng.js
@@ -1,0 +1,18 @@
+(function(global){
+  function seedFromString(s){
+    let h=1779033703^s.length;
+    for(let i=0;i<s.length;i++){ h=Math.imul(h^s.charCodeAt(i),3432918353); h=h<<13|h>>>19; }
+    return h>>>0;
+  }
+  function mulberry32(a){ return function(){ let t = a += 0x6D2B79F5;
+    t = Math.imul(t ^ t >>> 15, t | 1); t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+    return ((t ^ t >>> 14) >>> 0) / 4294967296; }; }
+  function makeRNG(seed){ const r = mulberry32(seed>>>0); return {
+    next:()=>r(), int:(min,max)=>Math.floor(r()*(max-min+1))+min, pick:(arr)=>arr[Math.floor(r()*arr.length)]
+  };}
+  const rollDice = (rng)=> [rng.int(1,6), rng.int(1,6)];
+
+  const api = { seedFromString, mulberry32, makeRNG, rollDice };
+  global.utils = Object.assign(global.utils || {}, api);
+  if (typeof module !== 'undefined') module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/js/utils/state_sanitize.js
+++ b/js/utils/state_sanitize.js
@@ -1,0 +1,64 @@
+(function(global){
+  const { assert, clamp } = global.utils || {};
+
+  function validateState(state, TILES){
+    const errs = [];
+    try {
+      if (!Array.isArray(state.players)) errs.push('players no es array');
+      state.players?.forEach((p,idx)=>{
+        if (typeof p.money!=='number') errs.push(`p${idx}.money inválido`);
+        if (p.pos<0 || p.pos>=TILES.length) errs.push(`p${idx}.pos fuera de rango`);
+      });
+      TILES.forEach((t,i)=>{
+        if (t.owner!=null && (t.owner<0 || t.owner>=state.players.length))
+          errs.push(`tile${i}.owner inválido`);
+        if (t.houses!=null && (t.houses<0 || t.houses>5)) errs.push(`tile${i}.houses inválido`);
+      });
+      const owners = new Map();
+      TILES.forEach((t,i)=>{
+        if (t.owner!=null){
+          const k = `${t.owner}:${t.family||t.color||'na'}:${i}`;
+          if (owners.has(k)) errs.push(`tile duplicada ${i}`); else owners.set(k,true);
+        }
+      });
+    } catch(e){ errs.push('Excepción en validate: '+e.message); }
+    return errs;
+  }
+
+  function repairState(state, TILES){
+    state.players.forEach(p=>{
+      if (!isFinite(p.money)) p.money = 0;
+      p.pos = clamp(p.pos|0, 0, TILES.length-1);
+      p.alive = !!p.alive;
+      if (p.jail!=null) p.jail = clamp(p.jail|0, 0, 10);
+    });
+    TILES.forEach(t=>{
+      if (t.owner!=null && (t.owner<0 || t.owner>=state.players.length)) t.owner=null;
+      if (t.houses!=null) t.houses = clamp(t.houses|0, 0, 5);
+      if (t.mortgaged!=null) t.mortgaged = !!t.mortgaged;
+    });
+    recomputeDerived(state, TILES);
+    return state;
+  }
+
+  function recomputeDerived(state, TILES){
+    const families = {};
+    TILES.forEach((t,i)=>{
+      const fam = t.family || t.color || 'na';
+      families[fam] ??= { count:0, ownedBy: new Map() };
+      families[fam].count++;
+      if (t.owner!=null) families[fam].ownedBy.set(t.owner, (families[fam].ownedBy.get(t.owner)||0)+1);
+    });
+    state.players.forEach((p,pi)=>{
+      p.monopolies = [];
+      Object.entries(families).forEach(([fam,info])=>{
+        if (info.ownedBy.get(pi) === info.count) p.monopolies.push(fam);
+      });
+      p.netWorth = (p.money|0) + TILES.reduce((s,t)=> s + (t.owner===pi ? (t.basePrice||0) + (t.houses||0)*(t.housePrice||0) : 0), 0);
+    });
+  }
+
+  const api = { validateState, repairState, recomputeDerived };
+  global.utils = Object.assign(global.utils || {}, api);
+  if (typeof module !== 'undefined') module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/js/utils/tx.js
+++ b/js/utils/tx.js
@@ -1,0 +1,34 @@
+(function(global){
+  function makeHistory(max=30){
+    const stack=[]; let idx=-1;
+    return {
+      snapshot(state){
+        const snap = structuredClone(state);
+        stack.splice(idx+1);
+        stack.push(snap);
+        if (stack.length>max) { stack.shift(); } else { idx++; }
+      },
+      canUndo(){ return idx>0; },
+      canRedo(){ return idx < stack.length-1; },
+      undo(){ if (idx>0) return structuredClone(stack[--idx]); },
+      redo(){ if (idx<stack.length-1) return structuredClone(stack[++idx]); },
+      peek(){ return structuredClone(stack[idx]); }
+    };
+  }
+
+  function withTransaction(history, state, fn){
+    history.snapshot(state);
+    try {
+      fn();
+      return { ok:true };
+    } catch(e){
+      const prev = history.undo();
+      Object.assign(state, prev);
+      return { ok:false, error:e };
+    }
+  }
+
+  const api = { makeHistory, withTransaction };
+  global.utils = Object.assign(global.utils || {}, api);
+  if (typeof module !== 'undefined') module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/js/utils/watchdog.js
+++ b/js/utils/watchdog.js
@@ -1,0 +1,16 @@
+(function(global){
+  function makeWatchdog(ms=3000){
+    let timer=null;
+    return {
+      arm(tag='op'){
+        clearTimeout(timer);
+        timer = setTimeout(()=>{ console.error('Watchdog timeout:', tag); throw new Error('Timeout '+tag); }, ms);
+      },
+      disarm(){ clearTimeout(timer); timer=null; }
+    };
+  }
+
+  const api = { makeWatchdog };
+  global.utils = Object.assign(global.utils || {}, api);
+  if (typeof module !== 'undefined') module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const utils = globalThis.utils || (globalThis.utils = {});
+if (typeof utils.assert !== 'function' && typeof require === 'function') {
+  try { Object.assign(utils, require('./utils/core.js')); } catch {}
+}
+
 /* v13 – Parte 2/7: motor de UI (tablero + casillas visibles tipo v11) */
 
 const V13_COLORS = {
@@ -8,7 +13,12 @@ const V13_COLORS = {
   bank:'#b91c1c', event:'#a855f7', util:'#64748b', rail:'#94a3b8', ferry:'#60a5fa', air:'#0ea5e9',
   start:'#10b981', tax:'#f59e0b', park:'#22c55e', gotojail:'#ef4444', jail:'#111827'
 };
-function colorFor(tile){ if(!tile) return '#475569'; const k=(tile.color||tile.subtype||tile.type||'').toLowerCase(); return V13_COLORS[k]||'#475569'; }
+function colorFor(tile){
+  utils.assert(tile == null || typeof tile === 'object', 'tile debe ser objeto');
+  if(!tile) return '#475569';
+  const k=(tile.color||tile.subtype||tile.type||'').toLowerCase();
+  return V13_COLORS[k]||'#475569';
+}
 
 const V13 = { tiles:[], state:null, els:[], boardEl:null };
 

--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -47,6 +47,11 @@
 (function(){
   'use strict';
 
+  const utils = globalThis.utils || (globalThis.utils = {});
+  if (typeof utils.makeRNG !== 'function' && typeof require === 'function') {
+    try { Object.assign(utils, require('./utils/rng.js')); } catch {}
+  }
+
   const R = {};
   const ROLE = {
     PROXENETA: 'proxeneta',
@@ -100,7 +105,17 @@
   };
 
   // Utilidades
-  const rand = {
+  let rng = null;
+  if (typeof cfg.rngSeed !== 'undefined' && utils.makeRNG) {
+    const seed = typeof cfg.rngSeed === 'string' ? utils.seedFromString(cfg.rngSeed) : cfg.rngSeed;
+    rng = utils.makeRNG(seed);
+  }
+  const rand = rng ? {
+    pick: arr => rng.pick(arr),
+    int: (min,max) => rng.int(min,max),
+    real: (min,max) => rng.next()*(max-min)+min,
+    chance: p => rng.next() < p
+  } : {
     pick(a){ return a[Math.floor(Math.random()*a.length)] },
     int(min, max){ return Math.floor(Math.random()*(max-min+1))+min },
     real(min, max){ return Math.random()*(max-min)+min },


### PR DESCRIPTION
## Summary
- add core utils for assertions, clamping, logging and more
- introduce RNG, state validation, transaction and watchdog helpers
- integrate utilities in board UI and roles module with optional deterministic RNG

## Testing
- `node --test`
- `node build.js`


------
https://chatgpt.com/codex/tasks/task_e_689ce04eed548324a4c2e7d41cce813e