### PR TITLE
Replace bitwise coercions in utils and test house clamping

### DIFF
--- a/js/utils/core.js
+++ b/js/utils/core.js
@@ -11,7 +11,7 @@
   }
 
   const toCents = (n) => (n==null?0:Math.round(Number(n)*100));
-  const fromCents = (c) => (c|0)/100;
+  const fromCents = (c) => Math.trunc(c || 0) / 100;
   const money = {
     add:(a,b)=>a+b,
     sub:(a,b)=>a-b,

--- a/js/utils/state_sanitize.js
+++ b/js/utils/state_sanitize.js
@@ -28,13 +28,13 @@
   function repairState(state, TILES){
     state.players.forEach(p=>{
       if (!isFinite(p.money)) p.money = 0;
-      p.pos = clamp(p.pos|0, 0, TILES.length-1);
+      p.pos = clamp(Math.trunc(p.pos || 0), 0, TILES.length-1);
       p.alive = !!p.alive;
-      if (p.jail!=null) p.jail = clamp(p.jail|0, 0, 10);
+      if (p.jail!=null) p.jail = clamp(Math.trunc(p.jail || 0), 0, 10);
     });
     TILES.forEach(t=>{
       if (t.owner!=null && (t.owner<0 || t.owner>=state.players.length)) t.owner=null;
-      if (t.houses!=null) t.houses = clamp(t.houses|0, 0, 5);
+      if (t.houses!=null) t.houses = clamp(Math.trunc(t.houses || 0), 0, 5);
       if (t.mortgaged!=null) t.mortgaged = !!t.mortgaged;
     });
     recomputeDerived(state, TILES);
@@ -54,7 +54,7 @@
       Object.entries(families).forEach(([fam,info])=>{
         if (info.ownedBy.get(pi) === info.count) p.monopolies.push(fam);
       });
-      p.netWorth = (p.money|0) + TILES.reduce((s,t)=> s + (t.owner===pi ? (t.basePrice||0) + (t.houses||0)*(t.housePrice||0) : 0), 0);
+      p.netWorth = Math.trunc(p.money || 0) + TILES.reduce((s,t)=> s + (t.owner===pi ? (t.basePrice||0) + (t.houses||0)*(t.housePrice||0) : 0), 0);
     });
   }
 

--- a/tests/repairStateHouses.test.js
+++ b/tests/repairStateHouses.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+require('../js/utils/core.js');
+const { repairState } = require('../js/utils/state_sanitize.js');
+
+test('repairState clamps houses to 5', () => {
+  const state = { players: [{ money: 0, pos: 0 }] };
+  const tiles = [{ owner: 0, houses: 99, basePrice: 100, housePrice: 50 }];
+  repairState(state, tiles);
+  assert.strictEqual(tiles[0].houses, 5);
+});


### PR DESCRIPTION
## Summary
- use `Math.trunc` instead of bitwise coercion in utility functions
- sanitize game state to clamp numeric fields without bitwise operations
- add unit test ensuring excessive house counts are capped at 5

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689ce76b1a888324b140f3ba8357a344