### PR TITLE
Handle refunds for mortgaged properties with houses

### DIFF
--- a/tests/repair_props.test.js
+++ b/tests/repair_props.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { repairProps } = require('../utils/repair_props.js');
+
+test('refund houses on mortgaged properties', () => {
+  const state = { players:[{money:100}] };
+  const tiles = [{ owner:0, mortgaged:true, houses:2, housePrice:30 }];
+  const events = repairProps(state, tiles, ()=>{});
+  assert.strictEqual(state.players[0].money, 160);
+  assert.strictEqual(tiles[0].houses, 0);
+  assert.deepStrictEqual(events, [{ index:0, refund:60 }]);
+});
+

--- a/utils/repair_props.js
+++ b/utils/repair_props.js
@@ -1,0 +1,20 @@
+(function(global){
+  function repairProps(state, TILES, log=console.log){
+    const refunds = [];
+    if(!state || !Array.isArray(state.players) || !Array.isArray(TILES)) return refunds;
+    TILES.forEach((t,i)=>{
+      if(t && t.mortgaged && (t.houses||0) > 0){
+        const refund = (t.houses||0) * (t.housePrice||0);
+        const owner = t.owner!=null ? state.players[t.owner] : null;
+        if(owner) owner.money = (owner.money||0) + refund;
+        refunds.push({ index:i, refund });
+        try { log(`refund ${refund} to player ${t.owner} for tile ${i}`); } catch(e){}
+        t.houses = 0;
+      }
+    });
+    return refunds;
+  }
+  const api = { repairProps };
+  global.utils = Object.assign(global.utils || {}, api);
+  if (typeof module !== 'undefined') module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- Refund house investments when mortgaged properties still contain houses
- Credit player balances during repair and expose refund events
- Test repairProps to ensure refunds and house reset

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689ce76bf2208324a19dc4d1ae52fdd0