### PR TITLE
Add basic Socket.IO infrastructure for hidden player turns

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,8 @@
 </script>
 <!-- JS bundle -->
 <script src="dist/bundle.js"></script>
+<script src="/socket.io/socket.io.js"></script>
+<script src="js/online.js"></script>
 
 
 

--- a/js/online.js
+++ b/js/online.js
@@ -1,0 +1,29 @@
+(() => {
+  const socket = io();
+
+  function joinGame(playerId) {
+    socket.emit('joinGame', playerId);
+  }
+
+  function sendAction(action, secret = false) {
+    socket.emit('playerAction', { action, secret });
+  }
+
+  function endTurn() {
+    socket.emit('endTurn');
+  }
+
+  socket.on('turn', (playerId) => {
+    console.log('Turno de', playerId);
+  });
+
+  socket.on('actionResult', (data) => {
+    console.log('Acción recibida', data);
+  });
+
+  socket.on('turnEnded', (playerId) => {
+    console.log('Turno finalizado de', playerId);
+  });
+
+  window.GameOnline = { joinGame, sendAction, endTurn };
+})();

--- a/package.json
+++ b/package.json
@@ -2,5 +2,13 @@
   "name": "artiako-landak-alpha-2",
   "version": "1.0.0",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.2"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+// Servir archivos estáticos del directorio actual
+app.use(express.static(__dirname));
+
+// Jugador en turno
+let currentTurn = null;
+
+io.on('connection', (socket) => {
+  // registrar jugador
+  socket.on('joinGame', (playerId) => {
+    socket.data.playerId = playerId;
+    if (currentTurn === null) {
+      currentTurn = playerId;
+      io.emit('turn', currentTurn);
+    }
+  });
+
+  // acciones de jugadores
+  socket.on('playerAction', ({ action, secret }) => {
+    const playerId = socket.data.playerId;
+    if (playerId !== currentTurn) return; // validar turno
+    const payload = { action, playerId };
+    if (secret) {
+      socket.emit('actionResult', payload);
+    } else {
+      io.emit('actionResult', payload);
+    }
+  });
+
+  // finalizar turno
+  socket.on('endTurn', () => {
+    const playerId = socket.data.playerId;
+    if (playerId === currentTurn) {
+      currentTurn = null;
+      io.emit('turnEnded', playerId);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express + Socket.IO server to track turns and send secret or public actions
- create a lightweight client wrapper to join games and emit hidden actions
- load the online client in the main page and expose npm scripts for running the server

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_689ce7a23c748324925d50e01f6eb7b1