### PR TITLE
Add online game join/share flow with host code

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,8 @@
 
     <div class="panelHeader">
     <h2 style="margin:0">Artiako Landak</h2>
-    <button id="openSetup" class="primary" type="button">Nueva partida</button>
-    <button id="shareGame" type="button">Compartir partida</button>
-    <button id="joinOnline" type="button">Unirse online</button>
+    <button id="openSetup" class="primary" type="button">Nueva partida local</button>
+    <button id="startOnline" type="button">Nueva partida online</button>
   </div>
 
   <!-- diálogo con la configuración original (IDs intactos) -->

--- a/js/online.js
+++ b/js/online.js
@@ -1,18 +1,22 @@
 (() => {
   const socket = io();
-  let playerKey = null;
+  let roomKey = null;
+  let playerId = null;
 
-  function joinGame(playerId) {
-    playerKey = playerId;
-    socket.emit('joinGame', playerId);
+  function joinGame(key) {
+    roomKey = key;
+    if (!playerId) {
+      playerId = Math.random().toString(36).slice(2, 8);
+    }
+    socket.emit('joinGame', { roomId: roomKey, playerId });
   }
 
   function shareGame() {
-    if (!playerKey) {
-      playerKey = Math.random().toString(36).slice(2, 8);
-      socket.emit('joinGame', playerKey);
+    if (!roomKey) {
+      roomKey = Math.random().toString(36).slice(2, 8);
     }
-    window.prompt('Comparte esta llave con tus amigos:', playerKey);
+    joinGame(roomKey);
+    window.prompt('Comparte esta llave con tus amigos:', roomKey);
   }
 
   function sendAction(action, secret = false) {
@@ -35,16 +39,16 @@
     console.log('Turno finalizado de', playerId);
   });
 
-  const joinBtn = document.getElementById('joinOnline');
-  const shareBtn = document.getElementById('shareGame');
+  const onlineBtn = document.getElementById('startOnline');
 
-  joinBtn?.addEventListener('click', () => {
-    const key = window.prompt('Ingresa la llave de la partida:');
-    if (key) joinGame(key);
-  });
-
-  shareBtn?.addEventListener('click', () => {
-    shareGame();
+  onlineBtn?.addEventListener('click', () => {
+    const share = window.confirm('¿Quieres compartir la partida?\nAceptar para compartir, cancelar para unirse');
+    if (share) {
+      shareGame();
+    } else {
+      const key = window.prompt('Ingresa la llave de la partida:');
+      if (key) joinGame(key);
+    }
   });
 
   window.GameOnline = { joinGame, sendAction, endTurn, shareGame };


### PR DESCRIPTION
## Summary
- Add separate Local and Online game entry points in the interface
- Introduce join/share logic on the client and room-based tracking on the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ced10e1a88324a340d0e4eb93e891