### PR TITLE
Enable log as chat in online mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,10 @@
   <!-- subasta y log fijos dentro del panel -->
   <div id="auction" class="auction" style="display:none"></div>
   <div class="log" id="log"></div>
+  <div class="chat" id="chatBox">
+    <input id="chatInput" type="text" placeholder="Escribe un mensaje" />
+    <button id="sendChat" type="button">Enviar</button>
+  </div>
 
   <details class="rules" id="rules" style="display:none;">
     <summary>Reglas</summary>

--- a/js/online.js
+++ b/js/online.js
@@ -31,6 +31,11 @@
     socket.emit('endTurn');
   }
 
+  function sendChat(message) {
+    if (!socket) return;
+    socket.emit('chatMessage', message);
+  }
+
   socket?.on('turn', (playerId) => {
     console.log('Turno de', playerId);
   });
@@ -43,7 +48,24 @@
     console.log('Turno finalizado de', playerId);
   });
 
+  socket?.on('chatMessage', ({ playerId: from, message }) => {
+    if (typeof log === 'function') {
+      log(`${from}: ${message}`);
+    } else {
+      console.log('Chat', from, message);
+    }
+  });
+
   const onlineBtn = document.getElementById('startOnline');
+  const chatInput = document.getElementById('chatInput');
+  const sendChatBtn = document.getElementById('sendChat');
+
+  function handleSendChat() {
+    const msg = chatInput?.value.trim();
+    if (!msg) return;
+    sendChat(msg);
+    chatInput.value = '';
+  }
 
   onlineBtn?.addEventListener('click', () => {
     if (!socket) {
@@ -59,5 +81,13 @@
     }
   });
 
-  window.GameOnline = { joinGame, sendAction, endTurn, shareGame };
+  sendChatBtn?.addEventListener('click', handleSendChat);
+  chatInput?.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSendChat();
+    }
+  });
+
+  window.GameOnline = { joinGame, sendAction, endTurn, shareGame, sendChat };
 })();

--- a/server.js
+++ b/server.js
@@ -47,6 +47,13 @@ io.on('connection', (socket) => {
     }
   });
 
+  // mensajes de chat
+  socket.on('chatMessage', (message) => {
+    const { playerId, roomId } = socket.data;
+    if (!roomId) return;
+    io.to(roomId).emit('chatMessage', { playerId, message });
+  });
+
   // finalizar turno
   socket.on('endTurn', () => {
     const { playerId, roomId } = socket.data;


### PR DESCRIPTION
## Summary
- Add server-side handler to broadcast chat messages to room participants
- Expose chat input and send button so players can talk via the log
- Log incoming chat messages and wire client-side socket events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf20a0ccc83248dab273f55e92173