### PR TITLE
Prevent state overpayment when funds depleted

### DIFF
--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -23,10 +23,18 @@ function transfer(from, to, amount, {taxable=false, reason=''}={}) {
 
   // Debitar
   if (from === Estado) {
-    Estado.money = Math.max(0, Math.round((Estado.money||0) - amount));
+    const available = Math.max(0, Math.round(Estado.money || 0));
+    if (available < amount) {
+      log?.(`💸 Estado sin fondos: intenta pagar ${fmtMoney(amount)}${reason ? ' — ' + reason : ''}.`);
+      amount = available; // pagar solo lo disponible (0 si nada)
+    }
+    Estado.money = Math.max(0, available - amount);
   } else if (from) {
     giveMoney(from, -amount, {taxable, reason});
   }
+
+  // Si no hay importe tras ajustar, salir
+  if (amount <= 0) { renderPlayers?.(); return; }
 
   // Acreditar
   if (to === Estado) {


### PR DESCRIPTION
## Summary
- Guard state payments: only disburse available funds and log when the state has insufficient money
- Rebuild bundle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf24b233483248e8e51655e84a22a