### PR TITLE
Centralize public funds, luck, and events

### DIFF
--- a/js/utils/economiaPublica.js
+++ b/js/utils/economiaPublica.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * EstadoEconomico centraliza el manejo de fondos públicos,
+ * la suerte y los eventos asociados. Evita duplicidades entre
+ * "dinero del Estado" y "dinero del gobierno".
+ */
+class EstadoEconomico {
+  constructor(fondosIniciales = 0) {
+    this.fondos = fondosIniciales;   // única bolsa de dinero
+    this.suerte = 0;                 // modificador de suerte
+    this.eventos = [];               // historial de eventos
+  }
+
+  /** Ingresa dinero a la bolsa pública */
+  recaudar(monto) {
+    if (!Number.isFinite(monto)) return;
+    this.fondos += monto;
+  }
+
+  /** Gasta de la bolsa pública, evitando valores negativos */
+  gastar(monto) {
+    if (!Number.isFinite(monto)) return false;
+    const m = Math.max(0, Math.round(monto));
+    if (m > this.fondos) return false;
+    this.fondos -= m;
+    return true;
+  }
+
+  /** Ajusta la suerte (positivo o negativo) */
+  modificarSuerte(delta) {
+    if (!Number.isFinite(delta)) return;
+    this.suerte += delta;
+  }
+
+  /**
+   * Ejecuta un evento que afecta dinero y suerte.
+   * @param {Object} opts
+   * @param {number} opts.costo       - lo que se resta de fondos.
+   * @param {number} opts.beneficio   - lo que se suma a fondos.
+   * @param {number} opts.efectoSuerte - modificador de suerte.
+   * @param {string} opts.descripcion - texto opcional del evento.
+   */
+  ejecutarEvento({ costo = 0, beneficio = 0, efectoSuerte = 0, descripcion = '' } = {}) {
+    this.gastar(costo);
+    this.recaudar(beneficio);
+    this.modificarSuerte(efectoSuerte);
+    if (descripcion) this.eventos.push(descripcion);
+  }
+}
+
+module.exports = { EstadoEconomico };

--- a/tests/economiaPublica.test.js
+++ b/tests/economiaPublica.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { EstadoEconomico } = require('../js/utils/economiaPublica.js');
+
+test('recaudar y gastar comparten la misma bolsa', () => {
+  const e = new EstadoEconomico(100);
+  e.recaudar(50);
+  const ok = e.gastar(30);
+  assert.strictEqual(ok, true);
+  assert.strictEqual(e.fondos, 120);
+});
+
+test('ejecutarEvento ajusta fondos y suerte', () => {
+  const e = new EstadoEconomico(200);
+  e.ejecutarEvento({ costo: 40, beneficio: 10, efectoSuerte: 5, descripcion: 'Prueba' });
+  assert.strictEqual(e.fondos, 170);
+  assert.strictEqual(e.suerte, 5);
+  assert.deepStrictEqual(e.eventos, ['Prueba']);
+});


### PR DESCRIPTION
## Summary
- Add `EstadoEconomico` class to manage a single pool of public funds along with luck and events
- Test that funds, luck, and event history are updated consistently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf290c9a88324bff5378c9429dd09