### PR TITLE
feat: add basic WebRTC P2P communication

### DIFF
--- a/js/online.js
+++ b/js/online.js
@@ -2,59 +2,113 @@
   const socket = typeof io !== 'undefined' ? io() : null;
   let roomKey;
   let playerId;
+  let pc;
+  let dataChannel;
 
-  function joinGame(key) {
+  function createPeer() {
+    pc = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+    });
+    pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        socket?.emit('signal', { roomId: roomKey, data: { candidate: event.candidate } });
+      }
+    };
+    pc.ondatachannel = (event) => {
+      dataChannel = event.channel;
+      setupDataChannel();
+    };
+  }
+
+  function setupDataChannel() {
+    if (!dataChannel) return;
+    dataChannel.onmessage = (e) => {
+      let msg;
+      try {
+        msg = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+      switch (msg.type) {
+        case 'turn':
+          console.log('Turno de', msg.playerId);
+          break;
+        case 'action':
+          console.log('Acción recibida', msg);
+          break;
+        case 'turnEnded':
+          console.log('Turno finalizado de', msg.playerId);
+          break;
+        case 'chat':
+          if (typeof log === 'function') {
+            log(`${msg.playerId}: ${msg.message}`);
+          } else {
+            console.log('Chat', msg.playerId, msg.message);
+          }
+          break;
+      }
+    };
+  }
+
+  async function joinGame(key) {
     if (!socket) return;
     roomKey = key;
     if (!playerId) {
       playerId = Math.random().toString(36).slice(2, 8);
     }
+    createPeer();
     socket.emit('joinGame', { roomId: roomKey, playerId });
   }
 
-  function shareGame() {
+  async function shareGame() {
     if (!socket) return;
     if (!roomKey) {
       roomKey = Math.random().toString(36).slice(2, 8);
     }
-    joinGame(roomKey);
+    await joinGame(roomKey);
+    dataChannel = pc.createDataChannel('game');
+    setupDataChannel();
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    socket.emit('signal', { roomId: roomKey, data: { sdp: pc.localDescription } });
     window.prompt('Comparte esta llave con tus amigos:', roomKey);
   }
 
+  socket?.on('signal', async ({ data }) => {
+    if (!pc) createPeer();
+    if (data.sdp) {
+      await pc.setRemoteDescription(data.sdp);
+      if (data.sdp.type === 'offer') {
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        socket.emit('signal', { roomId: roomKey, data: { sdp: pc.localDescription } });
+      }
+    } else if (data.candidate) {
+      try {
+        await pc.addIceCandidate(data.candidate);
+      } catch (err) {
+        console.error('Error adding ICE candidate', err);
+      }
+    }
+  });
+
+  function sendMessage(msg) {
+    if (dataChannel?.readyState === 'open') {
+      dataChannel.send(JSON.stringify(msg));
+    }
+  }
+
   function sendAction(action, secret = false) {
-    if (!socket) return;
-    socket.emit('playerAction', { action, secret });
+    sendMessage({ type: 'action', action, secret, playerId });
   }
 
   function endTurn() {
-    if (!socket) return;
-    socket.emit('endTurn');
+    sendMessage({ type: 'turnEnded', playerId });
   }
 
   function sendChat(message) {
-    if (!socket) return;
-    socket.emit('chatMessage', message);
+    sendMessage({ type: 'chat', playerId, message });
   }
-
-  socket?.on('turn', (playerId) => {
-    console.log('Turno de', playerId);
-  });
-
-  socket?.on('actionResult', (data) => {
-    console.log('Acción recibida', data);
-  });
-
-  socket?.on('turnEnded', (playerId) => {
-    console.log('Turno finalizado de', playerId);
-  });
-
-  socket?.on('chatMessage', ({ playerId: from, message }) => {
-    if (typeof log === 'function') {
-      log(`${from}: ${message}`);
-    } else {
-      console.log('Chat', from, message);
-    }
-  });
 
   const onlineBtn = document.getElementById('startOnline');
   const chatInput = document.getElementById('chatInput');
@@ -91,3 +145,4 @@
 
   window.GameOnline = { joinGame, sendAction, endTurn, shareGame, sendChat };
 })();
+

--- a/server.js
+++ b/server.js
@@ -54,6 +54,14 @@ io.on('connection', (socket) => {
     io.to(roomId).emit('chatMessage', { playerId, message });
   });
 
+  // intercambio de señalización para WebRTC
+  socket.on('signal', ({ roomId, data }) => {
+    const targetRoom = roomId || socket.data.roomId;
+    if (!targetRoom) return;
+    // reenviar datos de señalización al resto de jugadores
+    socket.to(targetRoom).emit('signal', { playerId: socket.data.playerId, data });
+  });
+
   // finalizar turno
   socket.on('endTurn', () => {
     const { playerId, roomId } = socket.data;


### PR DESCRIPTION
## Summary
- replace socket-based online module with WebRTC data channel implementation
- add signaling endpoint on server for peer-to-peer negotiation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf8e887ec832499b445dc92027617