### PR TITLE
fix: ensure board renders after modules load

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -258,12 +258,13 @@ function createTileElement(tile, index){
     }
   });
 
-  el.addEventListener('click', ()=>{
-    const current = V13.tiles[index];
-    if (current && typeof window.showCard === 'function'){
-      // Permitir iniciar subasta desde el click, si la propiedad está libre.
-      window.showCard(index); // por defecto canAuction=false
-    }
+  el.addEventListener('click', () => {
+    const idx = Number(el.dataset.idx);
+    const current = V13.tiles[idx];
+    if (!current || typeof window.showCard !== 'function') return;
+    // Permitir iniciar subasta desde el click, si la propiedad está libre.
+    const canAuction = current.type === 'prop' && current.owner === null;
+    window.showCard(idx, { canAuction });
   });
 
   el.appendChild(band); el.appendChild(head); el.appendChild(idTag); el.appendChild(badges); el.appendChild(meta);
@@ -457,8 +458,13 @@ function autoInit(){
   if (tiles.length){ window.BoardUI.renderBoard(); }
 }
 
-if (document.readyState !== 'loading') autoInit();
-else document.addEventListener('DOMContentLoaded', autoInit);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoInit);
+} else {
+  // Ensure other modules (like TILES) finish initializing before rendering
+  setTimeout(autoInit, 0);
+}
+
 'use strict';
 
 const COLORS = {

--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -255,5 +255,9 @@ function autoInit(){
   if (tiles.length){ window.BoardUI.renderBoard(); }
 }
 
-if (document.readyState !== 'loading') autoInit();
-else document.addEventListener('DOMContentLoaded', autoInit);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoInit);
+} else {
+  // Ensure other modules (like TILES) finish initializing before rendering
+  setTimeout(autoInit, 0);
+}


### PR DESCRIPTION
## Summary
- delay BoardUI auto-init until DOM and tile definitions are ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cfaa862488324bf8c246943c414ff