### PR TITLE
Retry board render until tiles ready

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -451,11 +451,15 @@ window.BoardUI = {
 };
 
 /* ==== Auto-init ==== */
-function autoInit(){
+function autoInit(attempt=0){
   const tiles = window.TILES || [];
   const state = window.state || null;
   window.BoardUI.attach({ tiles, state });
-  if (tiles.length){ window.BoardUI.renderBoard(); }
+  if (tiles.length){
+    window.BoardUI.renderBoard();
+  } else if (attempt < 10){
+    setTimeout(() => autoInit(attempt + 1), 100);
+  }
 }
 
 if (document.readyState === 'loading') {

--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -248,11 +248,15 @@ window.BoardUI = {
 };
 
 /* ==== Auto-init ==== */
-function autoInit(){
+function autoInit(attempt=0){
   const tiles = window.TILES || [];
   const state = window.state || null;
   window.BoardUI.attach({ tiles, state });
-  if (tiles.length){ window.BoardUI.renderBoard(); }
+  if (tiles.length){
+    window.BoardUI.renderBoard();
+  } else if (attempt < 10){
+    setTimeout(() => autoInit(attempt + 1), 100);
+  }
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Retry board UI initialization until tile data exists so squares always appear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d061788d08324b5fee257d7622fab