### PR TITLE
Implement multi-player government voting with tie-breaker

### DIFF
--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -159,14 +159,25 @@
   function openGovernmentElection(){
     uiLog('🗳️ Votación de gobierno abierta');
     if(typeof window.prompt !== 'function') return;
-    let s = window.prompt('Gobierno: left / right / authoritarian / libertarian', 'left');
-    if(!s){ uiLog('Voto cancelado'); return; }
-    s = s.trim().toLowerCase();
-    if(!['left','right','authoritarian','libertarian'].includes(s)){
-      uiLog('Voto cancelado');
-      return;
-    }
-    R.setGovernment(s);
+    const options = ['left','right','authoritarian','libertarian'];
+    const votes = new Map();
+    state.players.forEach(p=>{
+      let s = window.prompt(`Voto de ${p.name}: left / right / authoritarian / libertarian`, 'left');
+      if(!s) return;
+      s = s.trim().toLowerCase();
+      if(options.includes(s)){
+        votes.set(s, (votes.get(s)||0)+1);
+      }
+    });
+    if(votes.size===0){ uiLog('Votación sin votos válidos'); return; }
+    let max = 0;
+    const winners = [];
+    votes.forEach((cnt, side)=>{
+      if(cnt>max){ max=cnt; winners.length=0; winners.push(side); }
+      else if(cnt===max){ winners.push(side); }
+    });
+    const winner = rand.pick(winners);
+    R.setGovernment(winner);
   }
 
   // —— Asignación de roles ——

--- a/tests/governmentElection.test.js
+++ b/tests/governmentElection.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+global.window = { RolesConfig: { ui: { banner: false } } };
+global.document = { addEventListener: () => {} };
+global.localStorage = { setItem: () => {}, getItem: () => null };
+
+require('../js/v22_roles_politics.js');
+const Roles = global.window.Roles;
+
+test('government election selects majority vote', () => {
+  let i = 0;
+  window.prompt = () => ['left', 'right', 'left'][i++];
+  Roles.assign([{id:1},{id:2},{id:3}]);
+  assert.strictEqual(Roles.getGovernment(), 'left');
+});
+
+test('government election tie resolved randomly', () => {
+  let i = 0;
+  window.prompt = () => ['left', 'right'][i++];
+  const origRandom = Math.random;
+  Math.random = () => 0;
+  Roles.assign([{id:1},{id:2}]);
+  assert.strictEqual(Roles.getGovernment(), 'left');
+  i = 0;
+  window.prompt = () => ['left', 'right'][i++];
+  Math.random = () => 0.9;
+  Roles.openGovernmentElection();
+  assert.strictEqual(Roles.getGovernment(), 'right');
+  Math.random = origRandom;
+});


### PR DESCRIPTION
## Summary
- let every player vote on government type at game start and during elections
- resolve government vote ties randomly
- add tests covering majority selection and tie-breaking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d12d973c4832487c7f4ba53af8d2e