### PR TITLE
Evitar impugnaciones en subastas

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -2333,25 +2333,7 @@ function awardAuction(){
     price    = bestV;
   }
 
-  // Impugnación por un tercero antes de adjudicar
-  try {
-    const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-    if (who) {
-      const byId = Number(who) - 1;
-      const base = Math.max(1, t.price || 1);
-      const imbalance = Math.max(0, Math.min(1, (base - price) / base));
-      const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-      if (res.annulled) {
-        alert('⚖️ Juez IA anula la adjudicación.');
-        $('#auction').style.display = 'none';
-        state.auction = null;
-        const endTurnBtn = document.getElementById('endTurn');
-        if (endTurnBtn) endTurnBtn.disabled = false;
-        updateTurnButtons();
-        return;
-      }
-    }
-  } catch {}
+  // La impugnación se limita a los intercambios: las subastas no pueden impugnarse
 
   // Ganó Estado
   if (winnerId==='E'){
@@ -2703,22 +2685,7 @@ function animateTransportHop(player, fromIdx, toIdx, done){
       a.open = false;
 
       if (a.bestPlayer && a.bestBid > 0) {
-        // Impugnación por un tercero antes de adjudicar
-        try {
-          const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-          if (who) {
-            const byId = Number(who) - 1;
-            const base = Math.max(1, a.price || 1);
-            const imbalance = Math.max(0, Math.min(1, (base - a.bestBid) / base));
-            const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-            if (res.annulled) {
-              alert('⚖️ Juez IA anula la adjudicación.');
-              state.auction = null;
-              this._closeAuctionOverlay();
-              return;
-            }
-          }
-        } catch {}
+        // La impugnación solo aplica a intercambios, no a subastas
 
         if (a.kind === 'tile') {
           this._assignTileTo(a.assetId, a.bestPlayer, a.bestBid);

--- a/js/auction+debt-market-v21.js
+++ b/js/auction+debt-market-v21.js
@@ -113,22 +113,7 @@
       a.open = false;
 
       if (a.bestPlayer && a.bestBid > 0) {
-        // Impugnación por un tercero antes de adjudicar
-        try {
-          const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-          if (who) {
-            const byId = Number(who) - 1;
-            const base = Math.max(1, a.price || 1);
-            const imbalance = Math.max(0, Math.min(1, (base - a.bestBid) / base));
-            const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-            if (res.annulled) {
-              alert('⚖️ Juez IA anula la adjudicación.');
-              state.auction = null;
-              this._closeAuctionOverlay();
-              return;
-            }
-          }
-        } catch {}
+        // La impugnación solo aplica a intercambios, no a subastas
 
         if (a.kind === 'tile') {
           this._assignTileTo(a.assetId, a.bestPlayer, a.bestBid);

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -700,25 +700,7 @@ function awardAuction(){
     price    = bestV;
   }
 
-  // Impugnación por un tercero antes de adjudicar
-  try {
-    const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-    if (who) {
-      const byId = Number(who) - 1;
-      const base = Math.max(1, t.price || 1);
-      const imbalance = Math.max(0, Math.min(1, (base - price) / base));
-      const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-      if (res.annulled) {
-        alert('⚖️ Juez IA anula la adjudicación.');
-        $('#auction').style.display = 'none';
-        state.auction = null;
-        const endTurnBtn = document.getElementById('endTurn');
-        if (endTurnBtn) endTurnBtn.disabled = false;
-        updateTurnButtons();
-        return;
-      }
-    }
-  } catch {}
+  // La impugnación se limita a los intercambios: las subastas no pueden impugnarse
 
   // Ganó Estado
   if (winnerId==='E'){


### PR DESCRIPTION
## Summary
- Impedir que las subastas puedan ser impugnadas, dejando la impugnación solo para intercambios
- Regenerar bundle con los cambios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689da9d7367483249dbdc9bc51c1e49b