### PR TITLE
Restringir impugnación a terceros en intercambios

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -2333,25 +2333,7 @@ function awardAuction(){
     price    = bestV;
   }
 
-  // Impugnación por un tercero antes de adjudicar
-  try {
-    const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-    if (who) {
-      const byId = Number(who) - 1;
-      const base = Math.max(1, t.price || 1);
-      const imbalance = Math.max(0, Math.min(1, (base - price) / base));
-      const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-      if (res.annulled) {
-        alert('⚖️ Juez IA anula la adjudicación.');
-        $('#auction').style.display = 'none';
-        state.auction = null;
-        const endTurnBtn = document.getElementById('endTurn');
-        if (endTurnBtn) endTurnBtn.disabled = false;
-        updateTurnButtons();
-        return;
-      }
-    }
-  } catch {}
+  // La impugnación se limita a los intercambios: las subastas no pueden impugnarse
 
   // Ganó Estado
   if (winnerId==='E'){
@@ -2703,22 +2685,7 @@ function animateTransportHop(player, fromIdx, toIdx, done){
       a.open = false;
 
       if (a.bestPlayer && a.bestBid > 0) {
-        // Impugnación por un tercero antes de adjudicar
-        try {
-          const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-          if (who) {
-            const byId = Number(who) - 1;
-            const base = Math.max(1, a.price || 1);
-            const imbalance = Math.max(0, Math.min(1, (base - a.bestBid) / base));
-            const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-            if (res.annulled) {
-              alert('⚖️ Juez IA anula la adjudicación.');
-              state.auction = null;
-              this._closeAuctionOverlay();
-              return;
-            }
-          }
-        } catch {}
+        // La impugnación solo aplica a intercambios, no a subastas
 
         if (a.kind === 'tile') {
           this._assignTileTo(a.assetId, a.bestPlayer, a.bestBid);
@@ -4844,14 +4811,20 @@ async function trade(){
       }
 
       // Impugnación por un tercero antes de ejecutar el trato
-      const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
+      const who = prompt('Impugnación de jugador externo (ID) o vacío para seguir', '');
       if (who) {
-        const byId = Number(who)-1;
-        // desbalance (0..1) según ganancia neta
-        const denom   = Math.max(1, Math.abs(myGain)+Math.abs(otGain));
-        const imbalance = Math.min(1, Math.abs(myGain-otGain)/denom);
-        const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled:false };
-        if (res.annulled) { alert('⚖️ Juez IA anula el trato.'); return; }
+        const byId = Number(who) - 1;
+        // Solo se permite impugnar a jugadores ajenos al intercambio
+        const challenger = state.players[byId];
+        if (byId === me.id || byId === other.id || !challenger || !challenger.alive) {
+          alert('Solo puede impugnar un jugador que no participe en el intercambio.');
+        } else {
+          // desbalance (0..1) según ganancia neta
+          const denom = Math.max(1, Math.abs(myGain) + Math.abs(otGain));
+          const imbalance = Math.min(1, Math.abs(myGain - otGain) / denom);
+          const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
+          if (res.annulled) { alert('⚖️ Juez IA anula el trato.'); return; }
+        }
       }
 
   if (give>0 && me.money<give){ alert('No tienes suficiente dinero.'); return; }

--- a/js/auction+debt-market-v21.js
+++ b/js/auction+debt-market-v21.js
@@ -113,22 +113,7 @@
       a.open = false;
 
       if (a.bestPlayer && a.bestBid > 0) {
-        // Impugnación por un tercero antes de adjudicar
-        try {
-          const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-          if (who) {
-            const byId = Number(who) - 1;
-            const base = Math.max(1, a.price || 1);
-            const imbalance = Math.max(0, Math.min(1, (base - a.bestBid) / base));
-            const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-            if (res.annulled) {
-              alert('⚖️ Juez IA anula la adjudicación.');
-              state.auction = null;
-              this._closeAuctionOverlay();
-              return;
-            }
-          }
-        } catch {}
+        // La impugnación solo aplica a intercambios, no a subastas
 
         if (a.kind === 'tile') {
           this._assignTileTo(a.assetId, a.bestPlayer, a.bestBid);

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -700,25 +700,7 @@ function awardAuction(){
     price    = bestV;
   }
 
-  // Impugnación por un tercero antes de adjudicar
-  try {
-    const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
-    if (who) {
-      const byId = Number(who) - 1;
-      const base = Math.max(1, t.price || 1);
-      const imbalance = Math.max(0, Math.min(1, (base - price) / base));
-      const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
-      if (res.annulled) {
-        alert('⚖️ Juez IA anula la adjudicación.');
-        $('#auction').style.display = 'none';
-        state.auction = null;
-        const endTurnBtn = document.getElementById('endTurn');
-        if (endTurnBtn) endTurnBtn.disabled = false;
-        updateTurnButtons();
-        return;
-      }
-    }
-  } catch {}
+  // La impugnación se limita a los intercambios: las subastas no pueden impugnarse
 
   // Ganó Estado
   if (winnerId==='E'){

--- a/js/v20-part7.js
+++ b/js/v20-part7.js
@@ -571,14 +571,20 @@ async function trade(){
       }
 
       // Impugnación por un tercero antes de ejecutar el trato
-      const who = prompt('Impugnación del J3/J4… (ID de jugador) o vacío para seguir', '');
+      const who = prompt('Impugnación de jugador externo (ID) o vacío para seguir', '');
       if (who) {
-        const byId = Number(who)-1;
-        // desbalance (0..1) según ganancia neta
-        const denom   = Math.max(1, Math.abs(myGain)+Math.abs(otGain));
-        const imbalance = Math.min(1, Math.abs(myGain-otGain)/denom);
-        const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled:false };
-        if (res.annulled) { alert('⚖️ Juez IA anula el trato.'); return; }
+        const byId = Number(who) - 1;
+        // Solo se permite impugnar a jugadores ajenos al intercambio
+        const challenger = state.players[byId];
+        if (byId === me.id || byId === other.id || !challenger || !challenger.alive) {
+          alert('Solo puede impugnar un jugador que no participe en el intercambio.');
+        } else {
+          // desbalance (0..1) según ganancia neta
+          const denom = Math.max(1, Math.abs(myGain) + Math.abs(otGain));
+          const imbalance = Math.min(1, Math.abs(myGain - otGain) / denom);
+          const res = window.Roles?.challengeDeal?.({ byId, imbalance }) || { annulled: false };
+          if (res.annulled) { alert('⚖️ Juez IA anula el trato.'); return; }
+        }
       }
 
   if (give>0 && me.money<give){ alert('No tienes suficiente dinero.'); return; }


### PR DESCRIPTION
## Summary
- Evitar que las subastas puedan impugnarse
- Permitir que solo jugadores ajenos impugnen un intercambio
- Regenerar bundle con los cambios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da9d7367483249dbdc9bc51c1e49b