### PR TITLE
feat: add corrupt bank action menu

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -5,7 +5,7 @@
 const V13_COLORS = {
   brown:'#8b5a2b', cyan:'#22d3ee', pink:'#f472b6', orange:'#fb923c',
   red:'#ef4444', yellow:'#eab308', green:'#22c55e', blue:'#3b82f6', slots:'#d946ef',
-  bank:'#b91c1c', event:'#a855f7', util:'#64748b', rail:'#94a3b8', ferry:'#60a5fa', air:'#0ea5e9',
+  bank:'#991b1b', event:'#a855f7', util:'#64748b', rail:'#94a3b8', ferry:'#60a5fa', air:'#0ea5e9',
   start:'#10b981', tax:'#f59e0b', park:'#22c55e', gotojail:'#ef4444', jail:'#111827'
 };
 function colorFor(tile){ if(!tile) return '#475569'; const k=(tile.color||tile.subtype||tile.type||'').toLowerCase(); return V13_COLORS[k]||'#475569'; }
@@ -46,6 +46,7 @@ function createTileElement(tile, index){
 /* ==== Refresco de una casilla ==== */
 function refreshTile(i){
   const t = V13.tiles[i], el = V13.els[i]; if(!t||!el) return;
+  el.classList.toggle('bank', t.type==='bank');
   // Borde dorado si está hipotecada
   el.classList.toggle('mortgaged', !!(t && t.type==='prop' && t.mortgaged));
   el.querySelector('.name').textContent = t.name || '';
@@ -1668,6 +1669,25 @@ function promptDialog(message, defaultValue = '') {
   });
 }
 
+// Menú de acciones al caer en banca corrupta
+function showBankMenu(){
+  return new Promise(resolve => {
+    const dialog = document.getElementById('bankMenu');
+    if (!dialog){ resolve(null); return; }
+    const securiBtn = document.getElementById('bankMenuSecuritize');
+    const ticks   = Roles && RolesConfig ? (RolesConfig.securiTicks||3) : 3;
+    const advance = Roles && RolesConfig ? (RolesConfig.securiAdvance||150) : 150;
+    if (securiBtn) securiBtn.textContent = `Securitizar alquileres (${ticks} ticks, anticipo ${advance})`;
+    const handleClose = () => {
+      dialog.removeEventListener('close', handleClose);
+      const val = dialog.returnValue;
+      resolve(val && val !== 'cancel' ? val : null);
+    };
+    dialog.addEventListener('close', handleClose, { once:true });
+    dialog.showModal();
+  });
+}
+
 // === [PATCH] Ajuste de alquileres con eventos ===
 function adjustRentForEvents(payer, tile, base){
   let rent = Math.max(0, Math.round(base||0));
@@ -1735,36 +1755,25 @@ async function onLand(p, idx){
   // Si es una casilla de banca corrupta: menú rápido
   if (t.type === 'bank') {
     try {
-      const opt = await promptDialog(
-        'Banca corrupta:\n'
-        + '1) Préstamo corrupto\n'
-        + '2) Securitizar alquileres ('
-        + (Roles && RolesConfig ? (RolesConfig.securiTicks||3) : 3) + ' ticks, anticipo '
-        + (Roles && RolesConfig ? (RolesConfig.securiAdvance||150) : 150)
-        + ')\n3) Mercado deuda (GameDebtMarket)\n'
-        + '4) Titulización de préstamo\n(Enter = nada)',
-        ''
-      );
-      if (opt === '1') {
+      const opt = await showBankMenu();
+      if (opt === 'loan') {
         const A = Number(await promptDialog('Importe del préstamo:', '300'))||0;
         const Rr = Number(await promptDialog('Tipo (%, ej 20):', '20'))||0;
         const Tt = Number(await promptDialog('Ticks (<=30):', '12'))||0;
         const L = Roles.requestCorruptLoan({ playerId: p.id, amount: A, rate: Rr, ticks: Tt, tileId: idx });
         if (!L || !L.accepted) { alert((L && L.reason) ? L.reason : 'Rechazado'); }
         else {
-          // abona el principal al jugador (dinero “sale” del Estado si quieres reflejarlo)
           transfer(Estado, getPlayerById(p.id), A, { taxable:false, reason:'Préstamo corrupto' });
           log('Préstamo OK: devolver ' + L.dueAmount + ' en T' + L.dueTurn + '.');
         }
-      } else if (opt === '2') {
+      } else if (opt === 'securitize') {
         const S = Roles.corruptBankSecuritize({ playerId: p.id });
         if (!S || !S.ok) { alert((S && S.reason) ? S.reason : 'No se pudo securitizar'); }
         else {
-          // anticipo al jugador y a partir de ahora sus alquileres van al Estado por S.ticks
           transfer(Estado, getPlayerById(p.id), S.advance, { taxable:false, reason:'Securitización corrupta' });
           log('Securitización: cobras ' + S.advance + ' ahora; durante ' + S.ticks + ' ticks tus alquileres van al Estado.');
         }
-      } else if (opt === '3') {
+      } else if (opt === 'debt') {
         const principal = Number(await promptDialog('Principal préstamo deuda:', '300'))||0;
         const rate = Number(await promptDialog('Tipo (%):', '20'))||0;
         const term = Number(await promptDialog('Plazo (turnos):', '12'))||0;
@@ -1778,7 +1787,7 @@ async function onLand(p, idx){
         GameDebtMarket.addLoan(L);
         transfer(Estado, getPlayerById(p.id), principal, { taxable:false, reason:'Préstamo mercado deuda' });
         log('Mercado deuda: préstamo ' + L.id + ' creado.');
-      } else if (opt === '4') {
+      } else if (opt === 'titulize') {
         const loanId = await promptDialog('ID préstamo a titulizar:', '');
         if (loanId) {
           try {

--- a/index.html
+++ b/index.html
@@ -57,6 +57,22 @@
     </form>
   </dialog>
 
+  <!-- menú acciones banca corrupta -->
+  <dialog id="bankMenu">
+    <form method="dialog" class="bank-menu">
+      <p>Banca corrupta: elige operación</p>
+      <div class="menu">
+        <button value="loan" class="primary">Préstamo corrupto</button>
+        <button value="securitize" id="bankMenuSecuritize">Securitizar alquileres</button>
+        <button value="debt">Mercado de deuda</button>
+        <button value="titulize">Titulizar préstamo</button>
+      </div>
+      <div class="row" style="margin-top:8px; justify-content:flex-end">
+        <button value="cancel">Cancelar</button>
+      </div>
+    </form>
+  </dialog>
+
   <!-- diálogo para confirmar intercambios -->
   <dialog id="dealDialog">
     <div id="dealDetails"></div>

--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -5,7 +5,7 @@
 const V13_COLORS = {
   brown:'#8b5a2b', cyan:'#22d3ee', pink:'#f472b6', orange:'#fb923c',
   red:'#ef4444', yellow:'#eab308', green:'#22c55e', blue:'#3b82f6', slots:'#d946ef',
-  bank:'#b91c1c', event:'#a855f7', util:'#64748b', rail:'#94a3b8', ferry:'#60a5fa', air:'#0ea5e9',
+  bank:'#991b1b', event:'#a855f7', util:'#64748b', rail:'#94a3b8', ferry:'#60a5fa', air:'#0ea5e9',
   start:'#10b981', tax:'#f59e0b', park:'#22c55e', gotojail:'#ef4444', jail:'#111827'
 };
 function colorFor(tile){ if(!tile) return '#475569'; const k=(tile.color||tile.subtype||tile.type||'').toLowerCase(); return V13_COLORS[k]||'#475569'; }
@@ -46,6 +46,7 @@ function createTileElement(tile, index){
 /* ==== Refresco de una casilla ==== */
 function refreshTile(i){
   const t = V13.tiles[i], el = V13.els[i]; if(!t||!el) return;
+  el.classList.toggle('bank', t.type==='bank');
   // Borde dorado si está hipotecada
   el.classList.toggle('mortgaged', !!(t && t.type==='prop' && t.mortgaged));
   el.querySelector('.name').textContent = t.name || '';

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -35,6 +35,25 @@ function promptDialog(message, defaultValue = '') {
   });
 }
 
+// Menú de acciones al caer en banca corrupta
+function showBankMenu(){
+  return new Promise(resolve => {
+    const dialog = document.getElementById('bankMenu');
+    if (!dialog){ resolve(null); return; }
+    const securiBtn = document.getElementById('bankMenuSecuritize');
+    const ticks   = Roles && RolesConfig ? (RolesConfig.securiTicks||3) : 3;
+    const advance = Roles && RolesConfig ? (RolesConfig.securiAdvance||150) : 150;
+    if (securiBtn) securiBtn.textContent = `Securitizar alquileres (${ticks} ticks, anticipo ${advance})`;
+    const handleClose = () => {
+      dialog.removeEventListener('close', handleClose);
+      const val = dialog.returnValue;
+      resolve(val && val !== 'cancel' ? val : null);
+    };
+    dialog.addEventListener('close', handleClose, { once:true });
+    dialog.showModal();
+  });
+}
+
 // === [PATCH] Ajuste de alquileres con eventos ===
 function adjustRentForEvents(payer, tile, base){
   let rent = Math.max(0, Math.round(base||0));
@@ -102,36 +121,25 @@ async function onLand(p, idx){
   // Si es una casilla de banca corrupta: menú rápido
   if (t.type === 'bank') {
     try {
-      const opt = await promptDialog(
-        'Banca corrupta:\n'
-        + '1) Préstamo corrupto\n'
-        + '2) Securitizar alquileres ('
-        + (Roles && RolesConfig ? (RolesConfig.securiTicks||3) : 3) + ' ticks, anticipo '
-        + (Roles && RolesConfig ? (RolesConfig.securiAdvance||150) : 150)
-        + ')\n3) Mercado deuda (GameDebtMarket)\n'
-        + '4) Titulización de préstamo\n(Enter = nada)',
-        ''
-      );
-      if (opt === '1') {
+      const opt = await showBankMenu();
+      if (opt === 'loan') {
         const A = Number(await promptDialog('Importe del préstamo:', '300'))||0;
         const Rr = Number(await promptDialog('Tipo (%, ej 20):', '20'))||0;
         const Tt = Number(await promptDialog('Ticks (<=30):', '12'))||0;
         const L = Roles.requestCorruptLoan({ playerId: p.id, amount: A, rate: Rr, ticks: Tt, tileId: idx });
         if (!L || !L.accepted) { alert((L && L.reason) ? L.reason : 'Rechazado'); }
         else {
-          // abona el principal al jugador (dinero “sale” del Estado si quieres reflejarlo)
           transfer(Estado, getPlayerById(p.id), A, { taxable:false, reason:'Préstamo corrupto' });
           log('Préstamo OK: devolver ' + L.dueAmount + ' en T' + L.dueTurn + '.');
         }
-      } else if (opt === '2') {
+      } else if (opt === 'securitize') {
         const S = Roles.corruptBankSecuritize({ playerId: p.id });
         if (!S || !S.ok) { alert((S && S.reason) ? S.reason : 'No se pudo securitizar'); }
         else {
-          // anticipo al jugador y a partir de ahora sus alquileres van al Estado por S.ticks
           transfer(Estado, getPlayerById(p.id), S.advance, { taxable:false, reason:'Securitización corrupta' });
           log('Securitización: cobras ' + S.advance + ' ahora; durante ' + S.ticks + ' ticks tus alquileres van al Estado.');
         }
-      } else if (opt === '3') {
+      } else if (opt === 'debt') {
         const principal = Number(await promptDialog('Principal préstamo deuda:', '300'))||0;
         const rate = Number(await promptDialog('Tipo (%):', '20'))||0;
         const term = Number(await promptDialog('Plazo (turnos):', '12'))||0;
@@ -145,7 +153,7 @@ async function onLand(p, idx){
         GameDebtMarket.addLoan(L);
         transfer(Estado, getPlayerById(p.id), principal, { taxable:false, reason:'Préstamo mercado deuda' });
         log('Mercado deuda: préstamo ' + L.id + ' creado.');
-      } else if (opt === '4') {
+      } else if (opt === 'titulize') {
         const loanId = await promptDialog('ID préstamo a titulizar:', '');
         if (loanId) {
           try {

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,9 @@ button.primary{ background:#22c55e; border-color:#16a34a; color:#06280f; }
 dialog{ border:1px solid var(--border); border-radius:12px; padding:16px; background:#111827; color:var(--txt); max-width:420px }
 dialog::backdrop{ background:rgba(0,0,0,.55) }
 dialog .row input{ margin-left:6px; width:120px }
+#bankMenu form{ display:flex; flex-direction:column; gap:8px }
+#bankMenu .menu{ display:flex; flex-direction:column; gap:8px }
+#bankMenu .menu button{ width:100% }
 
 /* ======= estilos originales v15 (tablero, tiles, dados, etc.) ======= */
 /* letra más pequeña */
@@ -104,6 +107,10 @@ dialog .row input{ margin-left:6px; width:120px }
     border:2px solid #94a3b8; border-radius:10px;
     display:grid; grid-template-rows:auto 1fr auto; gap:4px;
     padding:6px; transition:transform .12s,box-shadow .12s; cursor:pointer;
+  }
+  .tile.bank{
+    background:linear-gradient(180deg,#581c1c,#3b0d0d);
+    border-color:#991b1b;
   }
 .tile:hover{ transform:translateY(-3px); box-shadow:0 0 8px rgba(255,255,255,.15); }
 .tile .band{ height:8px; border-radius:6px; box-shadow:inset 0 -1px 0 rgba(0,0,0,.35); }


### PR DESCRIPTION
## Summary
- polish corrupt bank tile with deeper red and distinct border
- mark bank tiles in UI for dedicated styling
- add modal menu for corrupt bank tile actions with professional layout

## Testing
- `node build.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689daaa373408324982d747d514c7adb