### PR TITLE
fix: prevent overlay toggle during auctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ Desde esta versión se incluye un modo P2P básico. Usa **Compartir** para actua
 
 ## Desarrollo
 - `js/utils/overlay.js` permite alternar la visibilidad del overlay mediante teclado.
-  El parámetro opcional `toggleKey` (por defecto `F2`) define la tecla usada.
+  El parámetro opcional `toggleKey` (por defecto `F2`) define la tecla usada. El overlay
+  no se ocultará mientras haya una subasta activa para evitar interferencias.

--- a/js/utils/overlay.js
+++ b/js/utils/overlay.js
@@ -1,5 +1,26 @@
 (function(global){
+  /**
+   * Enable toggling of the main overlay element via keyboard.
+   * During an active auction the overlay is left untouched to
+   * avoid interfering with the auction UI.
+   *
+   * @param {string} [toggleKey="F2"] - Key that toggles visibility.
+   */
+  function initOverlay(toggleKey = 'F2'){
+    const overlay = global.document?.getElementById('overlay');
+    if (!overlay) return;
 
+    document.addEventListener('keydown', (ev)=>{
+      if (ev.key !== toggleKey) return;
+      // Do not toggle overlay while an auction is running
+      if (global.state?.auction?.open) return;
+
+      const visible = getComputedStyle(overlay).display !== 'none';
+      overlay.style.display = visible ? 'none' : 'flex';
+    });
+  }
+
+  const api = { initOverlay };
   global.utils = Object.assign(global.utils || {}, api);
   if (typeof module !== 'undefined') module.exports = api;
 })(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- guard overlay toggling so it doesn't hide the auction UI
- document the behavior in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f44f1b7048324b521507229c42912