### PR TITLE
Handle Suerte tiles distinctly from generic events

### DIFF
--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -239,10 +239,12 @@ async function onLand(p, idx){
       playSlotsFree(p, t);
       break;
 
-    case 'event':
-      log(`🃏 ${p.name} cae en EVENTO.`);
-      try{ window.drawEvent?.(p); }catch(e){ log('Error al ejecutar evento.'); }
+    case 'event': {
+      const title = (t && t.name) ? t.name : 'Evento';
+      log(`🃏 ${p.name} cae en ${title.toUpperCase()}.`);
+      try { window.drawEvent?.(p, title); } catch (e) { log('Error al ejecutar evento.'); }
       break;
+    }
 
     case 'prop': {
       if (t.subtype==='fiore' && window.Roles && Roles.shouldBlockGame && Roles.shouldBlockGame('fiore')){

--- a/js/v20-part8.js
+++ b/js/v20-part8.js
@@ -480,7 +480,7 @@
   function ensureDeck(){ if (!state.eventDeck || !state.eventDeck.length) state.eventDeck = shuffle(EVENT_CARDS.slice()); }
 
   // Carta visible + ejecución del efecto
-  window.drawEvent = function(p){
+  window.drawEvent = function(p, titleOverride){
     let card = null;
     // [PATCH] Insider: usa el evento fijado si existe
     if (window.GameRiskPlus?.drawEventPatched) {
@@ -494,8 +494,12 @@
     // El objeto card puede venir del deck o del patcher.
     // Buscamos la descripción en el mapa global.
     const text = card.desc || EVENT_DESCS[card.name] || '';
+    const title = titleOverride || card.name;
+    const body  = (titleOverride && titleOverride !== card.name)
+      ? `${card.name}: ${text}`
+      : text;
     log(`🃏 Evento: <b>${card.name}</b>`);
-    showEventCard(card.name, text).then(()=>{
+    showEventCard(title, body).then(()=>{
       try {
         if (typeof window.resolverCarta === 'function') {
           // v22: Lógica unificada de eventos y efectos


### PR DESCRIPTION
## Summary
- Pass tile name to event handler and log the actual tile type (e.g., "Suerte")
- Allow event cards to override the title shown so luck tiles display "Suerte" while keeping card info

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dac79a9748324b7517afb776740b2