### PR TITLE
feat: show custom message on errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,20 @@
+const errorMessage = 'JODER JODER KOITXAU PUTE BAT NAZ, DANA TXARTO URTETAN YAT';
+
+// Override console error output and unhandled errors to show a custom message
+console.error = () => {
+  console.log(errorMessage);
+};
+
+process.on('uncaughtException', () => {
+  console.log(errorMessage);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', () => {
+  console.log(errorMessage);
+  process.exit(1);
+});
+
 const { WebSocketServer } = require('ws');
 const wss = new WebSocketServer({ port: 8080 });
 const rooms = new Map(); // roomId -> Set(ws)


### PR DESCRIPTION
## Summary
- override error logging to always show `JODER JODER KOITXAU PUTE BAT NAZ, DANA TXARTO URTETAN YAT`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f46fc760483248aac678217123f2c