### PR TITLE
feat: use choice dialog with buttons

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -837,11 +837,16 @@ const $$ = (q)=>Array.from(document.querySelectorAll(q));
 // Diálogo con botones para elegir opciones
 function promptChoice(message, options){
   return new Promise(resolve => {
-    const dlg = document.getElementById('choiceDialog');
+    let dlg = document.getElementById('choiceDialog');
     if (!dlg){
-      const fallback = window.prompt(message, options?.[0]?.value || '');
-      resolve(fallback);
-      return;
+      dlg = document.createElement('dialog');
+      dlg.id = 'choiceDialog';
+      dlg.innerHTML = `
+        <form method="dialog" id="choiceForm">
+          <p id="choiceMessage"></p>
+          <div id="choiceButtons" class="row" style="margin-top:8px; justify-content:flex-end; flex-wrap:wrap; gap:8px;"></div>
+        </form>`;
+      document.body.appendChild(dlg);
     }
     const msg = document.getElementById('choiceMessage');
     const box = document.getElementById('choiceButtons');

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -12,11 +12,16 @@ const $$ = (q)=>Array.from(document.querySelectorAll(q));
 // Diálogo con botones para elegir opciones
 function promptChoice(message, options){
   return new Promise(resolve => {
-    const dlg = document.getElementById('choiceDialog');
+    let dlg = document.getElementById('choiceDialog');
     if (!dlg){
-      const fallback = window.prompt(message, options?.[0]?.value || '');
-      resolve(fallback);
-      return;
+      dlg = document.createElement('dialog');
+      dlg.id = 'choiceDialog';
+      dlg.innerHTML = `
+        <form method="dialog" id="choiceForm">
+          <p id="choiceMessage"></p>
+          <div id="choiceButtons" class="row" style="margin-top:8px; justify-content:flex-end; flex-wrap:wrap; gap:8px;"></div>
+        </form>`;
+      document.body.appendChild(dlg);
     }
     const msg = document.getElementById('choiceMessage');
     const box = document.getElementById('choiceButtons');


### PR DESCRIPTION
## Summary
- Ensure option selection always uses a dialog with buttons instead of text prompts
- Rebuild bundle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f531720c48324b8c2d0d247c2560c