### PR TITLE
Show exercise option button only when player has options

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1031,6 +1031,21 @@ function renderPlayers(){
     }
   } catch(e) { console.warn('Error updating insider button', e); }
 
+  // [PATCH] Mostrar/ocultar botón "Ejercer opción"
+  try {
+    const exBtn = document.getElementById('exerciseOption');
+    if (exBtn) {
+      const p = state.players[state.current];
+      const opts = state.options?.filter(o => o.buyer === p.id) || [];
+      exBtn.style.display = opts.length ? '' : 'none';
+      if (opts.length) {
+        exBtn.textContent = `Ejercer opción (${opts.length})`;
+      } else {
+        exBtn.textContent = 'Ejercer opción';
+      }
+    }
+  } catch(e) { console.warn('Error updating exercise option button', e); }
+
   try { updatePropertyButtons(); } catch(e){ console.warn('Error updating property buttons', e); }
 }
 

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
     <button id="mortgage" type="button">Hipotecar</button>
     <button id="unmortgage" type="button">Levant. hipoteca</button>
     <button id="myBalance" type="button">Mi Balance</button>
-    <button id="exerciseOption" type="button">Ejercer opción</button>
+    <button id="exerciseOption" type="button" style="display:none;">Ejercer opción</button>
     <button id="insider" type="button" style="display:none;">Insider</button>
 
     <!-- los dados del v15 se siguen pintando aquí -->

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -206,6 +206,21 @@ function renderPlayers(){
     }
   } catch(e) { console.warn('Error updating insider button', e); }
 
+  // [PATCH] Mostrar/ocultar botón "Ejercer opción"
+  try {
+    const exBtn = document.getElementById('exerciseOption');
+    if (exBtn) {
+      const p = state.players[state.current];
+      const opts = state.options?.filter(o => o.buyer === p.id) || [];
+      exBtn.style.display = opts.length ? '' : 'none';
+      if (opts.length) {
+        exBtn.textContent = `Ejercer opción (${opts.length})`;
+      } else {
+        exBtn.textContent = 'Ejercer opción';
+      }
+    }
+  } catch(e) { console.warn('Error updating exercise option button', e); }
+
   try { updatePropertyButtons(); } catch(e){ console.warn('Error updating property buttons', e); }
 }
 


### PR DESCRIPTION
## Summary
- Hide "Ejercer opción" button by default in the action panel
- Display the button only when the active player owns option contracts and show the count
- Rebuild distribution bundle

## Testing
- `node build.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f52dd771c832482732f07b2dc6af3