### PR TITLE
feat: harden websocket signaling server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "node --test"
   },
   "dependencies": {
+    "ajv": "^8.12.0",
     "ws": "^8.18.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,34 +1,92 @@
-const errorMessage = 'JODER JODER KOITXAU PUTE BAT NAZ, DANA TXARTO URTETAN YAT';
-
-// Override console error output and unhandled errors to show a custom message
-console.error = () => {
-  console.log(errorMessage);
-};
-
-process.on('uncaughtException', () => {
-  console.log(errorMessage);
-  process.exit(1);
-});
-
-process.on('unhandledRejection', () => {
-  console.log(errorMessage);
-  process.exit(1);
-});
-
 const { WebSocketServer } = require('ws');
+const Ajv = require('ajv');
+
+const ajv = new Ajv();
+const schema = {
+  type: 'object',
+  properties: {
+    room: { type: 'string' },
+    type: { type: 'string' },
+    payload: {}
+  },
+  required: ['room', 'type']
+};
+const validate = ajv.compile(schema);
+
 const wss = new WebSocketServer({ port: 8080 });
 const rooms = new Map(); // roomId -> Set(ws)
 
-function inRoom(room){ const s = rooms.get(room); if(!s){ const n=new Set(); rooms.set(room,n); return n;} return s; }
+function safeRoomId(id) {
+  return String(id).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 32);
+}
 
-wss.on('connection', (ws)=>{
-  let room=null;
-  ws.on('message', (raw)=>{
-    let msg; try{ msg=JSON.parse(raw); }catch{ return; }
-    if (!room && msg.room){ room = msg.room; inRoom(room).add(ws); }
-    const set = inRoom(room);
-    for (const cli of set){ if (cli!==ws && cli.readyState===1) cli.send(raw); }
+function join(room, ws) {
+  let set = rooms.get(room);
+  if (!set) {
+    set = new Set();
+    rooms.set(room, set);
+  }
+  set.add(ws);
+}
+
+function broadcast(room, sender, data) {
+  const set = rooms.get(room);
+  if (!set) return;
+  for (const cli of set) {
+    if (cli !== sender && cli.readyState === 1) {
+      cli.send(data);
+    }
+  }
+}
+
+wss.on('connection', (ws) => {
+  ws.isAlive = true;
+  ws.on('pong', () => {
+    ws.isAlive = true;
   });
-  ws.on('close', ()=>{ if(room){ const set=inRoom(room); set.delete(ws); if(!set.size) rooms.delete(room); } });
+
+  let room = null;
+  ws.on('message', (raw) => {
+    const size = typeof raw === 'string' ? Buffer.byteLength(raw, 'utf8') : raw.length;
+    if (size > 32_768) return;
+
+    let msg;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!validate(msg)) return;
+
+    if (!room) {
+      room = safeRoomId(msg.room);
+      join(room, ws);
+    }
+
+    broadcast(room, ws, JSON.stringify({ type: msg.type, payload: msg.payload }));
+  });
+
+  ws.on('close', () => {
+    if (room) {
+      const set = rooms.get(room);
+      if (set) {
+        set.delete(ws);
+        if (!set.size) rooms.delete(room);
+      }
+    }
+  });
 });
+
+setInterval(() => {
+  for (const ws of wss.clients) {
+    if (!ws.isAlive) {
+      ws.terminate();
+    } else {
+      ws.isAlive = false;
+      ws.ping();
+    }
+  }
+}, 30_000);
+
 console.log('Signaling WS en ws://localhost:8080');
+


### PR DESCRIPTION
## Summary
- validate incoming messages with JSON schema and sanitize room IDs
- limit payload size and ping clients to drop dead sockets
- add Ajv dependency for schema validation

## Testing
- `npm install ajv` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ajv)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f55cc02588324a70c55a957b4ce40