### PR TITLE
Make dice numbers black

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,7 +137,7 @@ dialog .row input{ margin-left:6px; width:120px }
 /* Dados v15 (no tocados) */
 .diceWrap{display:flex;gap:12px;align-items:center;min-height:88px}
 .die{width:70px;height:70px;border-radius:12px;background:#fafafa;border:3px solid #111;display:grid;grid-template-rows:repeat(3,1fr);grid-template-columns:repeat(3,1fr);padding:8px;box-shadow:0 6px 18px rgba(0,0,0,.35)}
-.die.num{display:flex;align-items:center;justify-content:center;font-size:2rem;font-weight:700}
+.die.num{display:flex;align-items:center;justify-content:center;font-size:2rem;font-weight:700;color:#000}
 .pip{width:12px;height:12px;background:#111;border-radius:50%;align-self:center;justify-self:center}
 .diceMeta{font-size:.95rem;opacity:.9}
 .shaker{animation:shake .35s ease}


### PR DESCRIPTION
## Summary
- set `.die.num` style to use black text so dice numbers render clearly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f59befd988324af06ac560d6144d5