### PR TITLE
fix: prevent auction log overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -78,12 +78,13 @@ button.primary{ background:#22c55e; border-color:#16a34a; color:#06280f; }
   display:flex;
   flex-direction:column;
   gap:12px;
+  flex-shrink:0;
 }
 .auctionHeader h3{ margin:0; font-size:1.1rem; }
 .auctionPlayers{ display:flex; flex-direction:column; gap:4px; }
 
 .auctionActions{ display:flex; justify-content:flex-end; }
-.log{ background:#0d1117; border:1px solid #30363d; border-radius:12px; padding:10px; min-height:160px; max-height:380px; overflow:auto; font-family:ui-monospace,monospace; font-size:.9rem }
+.log{ background:#0d1117; border:1px solid #30363d; border-radius:12px; padding:10px; min-height:160px; max-height:380px; overflow:auto; font-family:ui-monospace,monospace; font-size:.9rem; flex-shrink:0 }
 
 /* diálogo de configuración */
 dialog{ border:1px solid var(--border); border-radius:12px; padding:16px; background:#111827; color:var(--txt); max-width:420px }


### PR DESCRIPTION
## Summary
- avoid overlapping between auction and log panels by disabling flex shrink

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f59afb5bc8324b5587cdd489470f3