### PR TITLE
Ensure property card initializes correctly

### DIFF
--- a/js/v20-part3.js
+++ b/js/v20-part3.js
@@ -373,7 +373,7 @@ let cardPriceRow, cardRentRow, cardBuildRow;
 let rentsBox, bankWarn, startAuctionBtn, cancelAuctionBtn;
 
 function initCardModal(){
-  if (overlay) return; // ya inicializado
+  // Re-obtener siempre los elementos por si el overlay fue reemplazado
   overlay       = document.getElementById('overlay');
   cardBand      = document.getElementById('cardBand');
   cardName      = document.getElementById('cardName');


### PR DESCRIPTION
## Summary
- Reinitialize the property card modal on each `showCard` use to rebuild element references if the overlay was replaced

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f5a3573488324be8b191f995166c9