### PR TITLE
Add simple P2P chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Artiako Landak es un juego de tablero que combina economía, subastas y roles op
 - **S**: guardar partida
 
 ## Juego en línea
-Desde esta versión se incluye un modo P2P básico. Usa **Compartir** para actuar como anfitrión (J1) y se generará un enlace que podrás enviar. Tus amigos pueden abrirlo y pulsar **Unirse** para conectarse como J2, J3, etc.
+Desde esta versión se incluye un modo P2P básico con chat integrado. Usa **Compartir** para actuar como anfitrión (J1) y se generará un enlace que podrás enviar. Tus amigos pueden abrirlo y pulsar **Unirse** para conectarse como J2, J3, etc. El chat permite enviar mensajes rápidos entre jugadores durante la partida.
 
 ## Desarrollo
 - `js/utils/overlay.js` permite alternar la visibilidad del overlay mediante teclado.

--- a/index.html
+++ b/index.html
@@ -116,6 +116,14 @@
   <div id="auction" class="auction" style="display:none"></div>
   <div class="log" id="log"></div>
 
+  <div id="chatBox" class="chat">
+    <div id="chatLog" class="chat-log"></div>
+    <div class="row chat-input">
+      <input id="chatInput" type="text" placeholder="Mensaje...">
+      <button id="chatSend" type="button">Enviar</button>
+    </div>
+  </div>
+
   <details class="rules" id="rules" style="display:none;">
     <summary>Reglas</summary>
     <ul>
@@ -190,6 +198,30 @@
     const wsUrl = `ws://${location.hostname}:8080`;
     Net.join(joinRoom, wsUrl);
   }
+
+  const chatLog = document.getElementById('chatLog');
+  const chatInput = document.getElementById('chatInput');
+  const chatSend = document.getElementById('chatSend');
+
+  function appendChat(msg, from){
+    const who = (Net.playerNum && from===Net.id)
+      ? `J${Net.playerNum}`
+      : (Net.peers.get(from)?.num ? `J${Net.peers.get(from).num}` : from);
+    const line = document.createElement('div');
+    line.textContent = `${who}: ${msg}`;
+    chatLog?.appendChild(line);
+    if (chatLog) chatLog.scrollTop = chatLog.scrollHeight;
+  }
+  Net.onChat = appendChat;
+
+  function send(){
+    const msg = chatInput?.value.trim();
+    if (!msg) return;
+    Net.sendChat(msg);
+    chatInput.value='';
+  }
+  chatSend?.addEventListener('click', send);
+  chatInput?.addEventListener('keydown', (e)=>{ if (e.key==='Enter') send(); });
 })();
 
 document.querySelectorAll('.tile').forEach(tile=>{

--- a/styles.css
+++ b/styles.css
@@ -218,3 +218,10 @@ body.playing .setup { justify-content:flex-end; gap:8px; }
   box-shadow: inset 0 0 0 2px rgba(245,158,11,.35);
 }
 
+/* Simple chat */
+.chat{ margin-top:8px; }
+.chat-log{ max-height:100px; overflow-y:auto; border:1px solid #ccc; padding:4px; background:#fff; }
+.chat-log div{ margin:2px 0; }
+.chat-input{ margin-top:4px; }
+.chat-input input{ flex:1; }
+


### PR DESCRIPTION
## Summary
- add chat panel to main interface for P2P games
- wire chat UI with Net.sendChat/onChat to broadcast messages
- document P2P chat support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5b31b3b4832499f982e12907a9b9