### PR TITLE
feat: mostrar subasta a pantalla completa

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -79,23 +79,26 @@ button.primary{ background:#22c55e; border-color:#16a34a; color:#06280f; }
 .actions{ width:100%; align-items:center }
 .actions > *{ height:auto }
 
-/* subasta + log pegados al panel */
+/* subasta a pantalla completa */
 .auction{
-  border:1px solid #f59e0b;
-  background:#1f2937;
-  padding:16px;
-  border-radius:12px;
-  font-size:1rem;
-  min-height:120px;
+  position:fixed;
+  top:0; left:0;
+  width:100vw;
+  height:100vh;
+  background:rgba(31,41,55,.95);
+  padding:40px;
+  font-size:1.1rem;
   display:flex;
   flex-direction:column;
+  justify-content:center;
+  align-items:center;
   gap:12px;
-  flex-shrink:0;
+  z-index:1000;
 }
-.auctionHeader h3{ margin:0; font-size:1.1rem; }
-.auctionPlayers{ display:flex; flex-direction:column; gap:4px; }
+.auctionHeader h3{ margin:0; font-size:1.5rem; }
+.auctionPlayers{ display:flex; flex-direction:column; gap:8px; width:100%; max-width:600px; }
 
-.auctionActions{ display:flex; justify-content:flex-end; }
+.auctionActions{ display:flex; justify-content:flex-end; width:100%; max-width:600px; }
 .log{ background:#0d1117; border:1px solid #30363d; border-radius:12px; padding:10px; min-height:160px; max-height:380px; overflow:auto; font-family:ui-monospace,monospace; font-size:.9rem; flex-shrink:0 }
 
 /* diálogo de configuración */


### PR DESCRIPTION
## Summary
- Cambia el estilo de la subasta para mostrarse como un popup a pantalla completa
- Ajusta tamaños y disposición de la cabecera, jugadores y acciones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f75fd76d08324b16839dea8724fd5