### PR TITLE
feat: handle property purchase rules for government

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -2092,6 +2092,23 @@ async function onLand(p, idx){
         break;
       }
       if (t.owner === null){
+        const gov = window.Roles?.getGovernment?.();
+        if (gov === 'left') {
+          log('Con un gobierno de izquierdas no se pueden comprar ni subastar propiedades.');
+          return;
+        } else if (gov === 'authoritarian') {
+          const price = t.price || 0;
+          if ((p.money || 0) >= price) {
+            transfer(p, Estado, price, { taxable:false, reason:`Compra directa ${t.name}` });
+            t.owner = p.id;
+            t.mortgaged = false;
+            try { recomputeProps?.(); BoardUI.refreshTiles?.(); } catch {}
+            log(`${p.name} compra ${t.name} por ${price} sin subasta.`);
+          } else {
+            log(`${p.name} no tiene dinero para comprar ${t.name}.`);
+          }
+          return;
+        }
         // [PATCH] Nueva gestión de subastas con Debt Market
         if (window.GameDebtMarket && window.GameDebtMarket.onLandProperty) {
           GameDebtMarket.onLandProperty(idx, t);

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -369,6 +369,23 @@ async function onLand(p, idx){
         break;
       }
       if (t.owner === null){
+        const gov = window.Roles?.getGovernment?.();
+        if (gov === 'left') {
+          log('Con un gobierno de izquierdas no se pueden comprar ni subastar propiedades.');
+          return;
+        } else if (gov === 'authoritarian') {
+          const price = t.price || 0;
+          if ((p.money || 0) >= price) {
+            transfer(p, Estado, price, { taxable:false, reason:`Compra directa ${t.name}` });
+            t.owner = p.id;
+            t.mortgaged = false;
+            try { recomputeProps?.(); BoardUI.refreshTiles?.(); } catch {}
+            log(`${p.name} compra ${t.name} por ${price} sin subasta.`);
+          } else {
+            log(`${p.name} no tiene dinero para comprar ${t.name}.`);
+          }
+          return;
+        }
         // [PATCH] Nueva gestión de subastas con Debt Market
         if (window.GameDebtMarket && window.GameDebtMarket.onLandProperty) {
           GameDebtMarket.onLandProperty(idx, t);


### PR DESCRIPTION
## Summary
- Block property purchase and auctions under left governments
- Allow direct property purchases at listed price when government is authoritarian

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f770c80cc8324907a4f09353dd87d