### PR TITLE
Drop rent securitization from corrupt bank

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,6 @@
       <p>Banca corrupta: elige operación</p>
       <div class="menu">
         <button value="loan" class="primary">Préstamo corrupto</button>
-        <button value="securitize" id="bankMenuSecuritize">Securitizar alquileres</button>
         <button value="debt">Mercado de deuda</button>
         <button value="titulize">Titulizar préstamo</button>
         <button value="options">Derivados de propiedades</button>

--- a/js/v20-part3.js
+++ b/js/v20-part3.js
@@ -536,7 +536,7 @@ const FUNNY = {
   gotojail: 'A la cárcel, a la cárcel, a la cárcel, a la cárcel, a la cárcel…',
   park:     'buen sitio pa fumar porros',
   slots:    'GANA GANA GANA!!!',
-  bank:     'Banca corrupta: pide préstamo o securitiza tus deudas.',
+  bank:     'Banca corrupta: pide préstamo o tituliza deudas.',
   default:  'Sin info, como tu madre...'
 };
 

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -40,10 +40,6 @@ function showBankMenu(){
   return new Promise(resolve => {
     const dialog = document.getElementById('bankMenu');
     if (!dialog){ resolve(null); return; }
-    const securiBtn = document.getElementById('bankMenuSecuritize');
-    const ticks   = Roles && RolesConfig ? (RolesConfig.securiTicks||3) : 3;
-    const advance = Roles && RolesConfig ? (RolesConfig.securiAdvance||150) : 150;
-    if (securiBtn) securiBtn.textContent = `Securitizar alquileres (${ticks} ticks, anticipo ${advance})`;
     const handleClose = () => {
       dialog.removeEventListener('close', handleClose);
       const val = dialog.returnValue;
@@ -221,13 +217,6 @@ async function onLand(p, idx){
         else {
           transfer(Estado, getPlayerById(p.id), A, { taxable:false, reason:'Préstamo corrupto' });
           log('Préstamo OK: devolver ' + L.dueAmount + ' en T' + L.dueTurn + '.');
-        }
-      } else if (opt === 'securitize') {
-        const S = Roles.corruptBankSecuritize({ playerId: p.id });
-        if (!S || !S.ok) { alert((S && S.reason) ? S.reason : 'No se pudo securitizar'); }
-        else {
-          transfer(Estado, getPlayerById(p.id), S.advance, { taxable:false, reason:'Securitización corrupta' });
-          log('Securitización: cobras ' + S.advance + ' ahora; durante ' + S.ticks + ' ticks tus alquileres van al Estado.');
         }
       } else if (opt === 'debt') {
         const principal = Number(await promptDialog('Principal préstamo deuda:', '300'))||0;
@@ -508,12 +497,6 @@ async function onLand(p, idx){
               if (window.Roles?.shouldRedirectRentToEstado?.(idx)) {
                 redirectToEstado = true;
                 reason = 'Renta embargada';
-              }
-              // Securitización del PROPIETARIO (redirige TODAS sus rentas durante X ticks)
-              const ownerId = t.owner;
-              if (!redirectToEstado && window.Roles?.shouldRedirectRentToEstadoForOwner?.(ownerId)) {
-                redirectToEstado = true;
-                reason = 'Renta securitizada';
               }
             } catch (e) {}
 

--- a/js/v20-part7.js
+++ b/js/v20-part7.js
@@ -865,14 +865,6 @@ async function tryCorruptLoan() {
         transfer(Estado, p, A, { taxable:false, reason:'Préstamo corrupto' });
         log('Préstamo OK: devolver ' + L.dueAmount + ' en T' + L.dueTurn + '.');
       }
-    } else if (opt === 'securitize') {
-      const S = window.Roles?.corruptBankSecuritize?.({ playerId: p.id });
-      if (!S?.ok) {
-        alert((S && S.reason) ? S.reason : 'No se pudo securitizar');
-      } else {
-        transfer(Estado, p, S.advance, { taxable:false, reason:'Securitización corrupta' });
-        log('Securitización: cobras ' + S.advance + ' ahora; durante ' + S.ticks + ' ticks tus alquileres van al Estado.');
-      }
     } else if (opt === 'debt') {
       const principal = Number(await promptDialog('Principal préstamo deuda:', '300'))||0;
       const rate = Number(await promptDialog('Tipo (%):', '20'))||0;


### PR DESCRIPTION
## Summary
- Remove "Securitizar alquileres" option and related logic from corrupt bank flows
- Clean roles/politics module of rent securitization state and config
- Update help text for corrupt bank and rebuild bundle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f872d75f88324853f29d4e89a2bfc