### PR TITLE
feat: display game end popup

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -933,6 +933,27 @@ window.ensureVAT      = ensureVAT;
 window.markIVAPaid    = markIVAPaid;
 window.markIVACharged = markIVACharged;
 
+function endGame(message){
+  let dlg = document.getElementById('endGameDialog');
+  if(!dlg){
+    dlg = document.createElement('dialog');
+    dlg.id = 'endGameDialog';
+    dlg.innerHTML = `
+      <p id="endGameMessage"></p>
+      <div class="row" style="margin-top:8px; justify-content:flex-end">
+        <button id="endGameRestart" class="primary">Nueva partida</button>
+      </div>`;
+    document.body.appendChild(dlg);
+    const btn = document.getElementById('endGameRestart');
+    btn.addEventListener('click', ()=>{ location.reload(); });
+    dlg.addEventListener('cancel', ev=>ev.preventDefault());
+  }
+  const msg = document.getElementById('endGameMessage');
+  if(msg) msg.textContent = message;
+  dlg.showModal();
+}
+window.endGame = endGame;
+
 function ensureAlive(player){
   if (!player || player===Estado) return;
   if (player.money >= 0) return;
@@ -950,6 +971,11 @@ function ensureAlive(player){
   if (state.current === player.id) endTurn(); // pasa turno si el activo muere
   BoardUI.refreshTiles();
   renderPlayers();
+
+  const vivos = state.players.filter(p=>p.alive);
+  if (vivos.length === 1){
+    endGame(`Zorionak ${vivos[0].name} ha ganado.`);
+  }
 }
 
 function updatePropertyButtons(){
@@ -5119,8 +5145,7 @@ function checkBankrupt(p){
   renderAll();
 }
 function everyoneLoses(){
-  alert('El ESTADO ha eliminado a un jugador. Todos pierden.');
-  location.reload();
+  endGame('El ESTADO ha eliminado a un jugador. Todos pierden.');
 }
 
 /* =================== IA del ESTADO (ligera) =================== */

--- a/js/v20-part4.js
+++ b/js/v20-part4.js
@@ -106,6 +106,27 @@ window.ensureVAT      = ensureVAT;
 window.markIVAPaid    = markIVAPaid;
 window.markIVACharged = markIVACharged;
 
+function endGame(message){
+  let dlg = document.getElementById('endGameDialog');
+  if(!dlg){
+    dlg = document.createElement('dialog');
+    dlg.id = 'endGameDialog';
+    dlg.innerHTML = `
+      <p id="endGameMessage"></p>
+      <div class="row" style="margin-top:8px; justify-content:flex-end">
+        <button id="endGameRestart" class="primary">Nueva partida</button>
+      </div>`;
+    document.body.appendChild(dlg);
+    const btn = document.getElementById('endGameRestart');
+    btn.addEventListener('click', ()=>{ location.reload(); });
+    dlg.addEventListener('cancel', ev=>ev.preventDefault());
+  }
+  const msg = document.getElementById('endGameMessage');
+  if(msg) msg.textContent = message;
+  dlg.showModal();
+}
+window.endGame = endGame;
+
 function ensureAlive(player){
   if (!player || player===Estado) return;
   if (player.money >= 0) return;
@@ -123,6 +144,11 @@ function ensureAlive(player){
   if (state.current === player.id) endTurn(); // pasa turno si el activo muere
   BoardUI.refreshTiles();
   renderPlayers();
+
+  const vivos = state.players.filter(p=>p.alive);
+  if (vivos.length === 1){
+    endGame(`Zorionak ${vivos[0].name} ha ganado.`);
+  }
 }
 
 function updatePropertyButtons(){

--- a/js/v20-part7.js
+++ b/js/v20-part7.js
@@ -634,8 +634,7 @@ function checkBankrupt(p){
   renderAll();
 }
 function everyoneLoses(){
-  alert('El ESTADO ha eliminado a un jugador. Todos pierden.');
-  location.reload();
+  endGame('El ESTADO ha eliminado a un jugador. Todos pierden.');
 }
 
 /* =================== IA del ESTADO (ligera) =================== */


### PR DESCRIPTION
## Summary
- add endGame modal to announce winner and restart option
- trigger modal when only one player remains
- show modal on state elimination

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a07c982d5c8324ba302080b8b37bff