### PR TITLE
Simplify corrupt bank options and animate blackjack

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1956,33 +1956,36 @@ async function onLand(p, idx){
         transfer(Estado, getPlayerById(p.id), principal, { taxable:false, reason:'Préstamo mercado deuda' });
         log('Mercado deuda: préstamo ' + L.id + ' creado.');
       } else if (opt === 'titulize') {
-        const loanId = await promptDialog('ID préstamo a titulizar:', '');
-        if (loanId) {
-          try {
-            const shares = GameSecuritization.splitLoan(loanId, [
-              { ownerId: p.id, bips: 5000 },
-              { ownerId: 'E', bips: 5000 }
-            ]);
-            if (shares) {
-              log('Titulización OK: ' + shares.join(','));
-            } else {
-              alert('No se pudo titulizar');
+        const p2p = (state.loans||[]).filter(l => state.players[l.lenderId] && state.players[l.borrowerId]);
+        if (!p2p.length) {
+          alert('No hay préstamos P2P para titulizar');
+        } else {
+          const choice = await promptChoice('Elige préstamo P2P a titulizar:', p2p.map(l => ({ text:`${l.id} (${l.principal})`, value:l.id })));
+          if (choice) {
+            try {
+              const shares = GameSecuritization.splitLoan(choice, [
+                { ownerId: p.id, bips: 5000 },
+                { ownerId: 'E', bips: 5000 }
+              ]);
+              if (shares) {
+                log('Titulización OK: ' + shares.join(','));
+              } else {
+                alert('No se pudo titulizar');
+              }
+            } catch (e) {
+              alert('Error titulizando: ' + e.message);
             }
-          } catch (e) {
-            alert('Error titulizando: ' + e.message);
           }
         }
       } else if (opt === 'options') {
-        const action = (await promptDialog('Operación (sell/exercise):', 'sell') || '').toLowerCase();
-        if (action === 'sell') {
-          const propName = await promptDialog('Nombre propiedad:', '');
-          const tile = TILES.find(t => t.name === propName && t.owner === p.id);
-          if (!tile) {
-            alert('No posees esa propiedad');
-          } else {
-            const typeOpt = (await promptDialog('Tipo (call/put):', 'call') || '').toLowerCase();
-            const strike = Number(await promptDialog('Precio ejercicio:', '100')) || 0;
-            const premium = Number(await promptDialog('Prima:', '10')) || 0;
+        const owned = TILES.filter(t => t.owner === p.id);
+        if (!owned.length) {
+          alert('No tienes propiedades para opciones');
+        } else {
+          const propName = await promptChoice('Propiedad para opción de compra:', owned.map(t => ({ text:t.name, value:t.name })));
+          if (propName) {
+            const strike = Number(await promptDialog('Precio de ejercicio:', '100')) || 0;
+            const premium = Number(await promptDialog('Precio de la opción:', '10')) || 0;
             const buyerId = await promptDialog('ID comprador:', '');
             const buyer = state.players[buyerId];
             if (!buyer) {
@@ -1990,13 +1993,11 @@ async function onLand(p, idx){
             } else if (buyer.money < premium) {
               alert('Comprador sin fondos');
             } else {
-              transfer(buyer, getPlayerById(p.id), premium, { taxable:false, reason: `Prima opción ${typeOpt}` });
-              state.options.push({ property: tile.name, type: typeOpt, strike, premium, seller: p.id, buyer: buyerId });
-              log(`Opción ${typeOpt} sobre ${tile.name} vendida a ${buyer.name}.`);
+              transfer(buyer, getPlayerById(p.id), premium, { taxable:false, reason:'Prima opción call' });
+              state.options.push({ property: propName, type:'call', strike, premium, seller: p.id, buyer: buyerId });
+              log(`Opción call sobre ${propName} vendida a ${buyer.name}.`);
             }
           }
-        } else if (action === 'exercise') {
-          await exerciseOption(p);
         }
       }
     } catch(e){}
@@ -4298,6 +4299,22 @@ function animateTransportHop(player, fromIdx, toIdx, done){
     return cards.slice(0,3);
   }
 
+  function spinCard(el, final){
+    const symbols = [2,3,4,5,6,7,8,9,10,11];
+    const start = performance.now();
+    const duration = 500;
+    function tick(t){
+      if (t - start < duration){
+        el.textContent = String(symbols[Math.floor(Math.random()*symbols.length)]);
+        requestAnimationFrame(tick);
+      } else {
+        el.textContent = String(final);
+        el.classList.add('in');
+      }
+    }
+    requestAnimationFrame(tick);
+  }
+
   // === Blackjack con animación
   window.playBlackjack = async function(player, owner, tile){
     if (!owner || owner.alive === false){ log('El dueño no puede actuar.'); return; }
@@ -4355,11 +4372,12 @@ function animateTransportHop(player, fromIdx, toIdx, done){
     const dCards = fakeCardsFor(dealer);
     let dSum = 0;
     for (const v of dCards){
-      const c = document.createElement('div'); c.className='card'; c.textContent=String(v);
+      const c = document.createElement('div'); c.className='card'; c.textContent='?';
       dRow.querySelector('.bjCards').appendChild(c);
-      await sleep(40); c.classList.add('in'); dSum += v;
+      spinCard(c, v);
+      await sleep(600);
+      dSum += v;
       dRow.querySelector('.total').textContent = String(dSum);
-      await sleep(160);
     }
 
     // Jugadores
@@ -4373,11 +4391,12 @@ function animateTransportHop(player, fromIdx, toIdx, done){
       const cards = fakeCardsFor(r.me);
       let sum = 0;
       for (const v of cards){
-        const c = document.createElement('div'); c.className='card'; c.textContent=String(v);
+        const c = document.createElement('div'); c.className='card'; c.textContent='?';
         row.querySelector('.bjCards').appendChild(c);
-        await sleep(40); c.classList.add('in'); sum += v;
+        spinCard(c, v);
+        await sleep(600);
+        sum += v;
         row.querySelector('.total').textContent = String(sum);
-        await sleep(140);
       }
       if (r.dealerWins) row.classList.add('lose'); else row.classList.add('win');
     }

--- a/js/v20-casino-ani.js
+++ b/js/v20-casino-ani.js
@@ -84,6 +84,22 @@
     return cards.slice(0,3);
   }
 
+  function spinCard(el, final){
+    const symbols = [2,3,4,5,6,7,8,9,10,11];
+    const start = performance.now();
+    const duration = 500;
+    function tick(t){
+      if (t - start < duration){
+        el.textContent = String(symbols[Math.floor(Math.random()*symbols.length)]);
+        requestAnimationFrame(tick);
+      } else {
+        el.textContent = String(final);
+        el.classList.add('in');
+      }
+    }
+    requestAnimationFrame(tick);
+  }
+
   // === Blackjack con animación
   window.playBlackjack = async function(player, owner, tile){
     if (!owner || owner.alive === false){ log('El dueño no puede actuar.'); return; }
@@ -141,11 +157,12 @@
     const dCards = fakeCardsFor(dealer);
     let dSum = 0;
     for (const v of dCards){
-      const c = document.createElement('div'); c.className='card'; c.textContent=String(v);
+      const c = document.createElement('div'); c.className='card'; c.textContent='?';
       dRow.querySelector('.bjCards').appendChild(c);
-      await sleep(40); c.classList.add('in'); dSum += v;
+      spinCard(c, v);
+      await sleep(600);
+      dSum += v;
       dRow.querySelector('.total').textContent = String(dSum);
-      await sleep(160);
     }
 
     // Jugadores
@@ -159,11 +176,12 @@
       const cards = fakeCardsFor(r.me);
       let sum = 0;
       for (const v of cards){
-        const c = document.createElement('div'); c.className='card'; c.textContent=String(v);
+        const c = document.createElement('div'); c.className='card'; c.textContent='?';
         row.querySelector('.bjCards').appendChild(c);
-        await sleep(40); c.classList.add('in'); sum += v;
+        spinCard(c, v);
+        await sleep(600);
+        sum += v;
         row.querySelector('.total').textContent = String(sum);
-        await sleep(140);
       }
       if (r.dealerWins) row.classList.add('lose'); else row.classList.add('win');
     }


### PR DESCRIPTION
## Summary
- Limit corrupt bank derivatives to call options with property selection and premium/strike inputs
- Allow only peer-to-peer loans to be securitized
- Add slot-style card spin animation to blackjack

## Testing
- `node build.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07d5ac318832490365bf1d7eb4f8f