### PR TITLE
Fix property card overlay display

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,19 +190,6 @@
 
   })();
 
-document.querySelectorAll('.tile').forEach((tile, idx) => {
-  tile.addEventListener('click', (e) => {
-    e.stopPropagation();
-    tile.classList.toggle('active');
-    const ov = document.getElementById('overlay');
-    if (typeof window.showCard === 'function' && ov?.style.display !== 'flex') {
-      window.showCard(idx);
-    }
-  });
-});
-document.querySelectorAll('.badge').forEach(badge=>{
-  badge.addEventListener('click',(e)=>{ e.stopPropagation(); badge.classList.toggle('active'); });
-});
 
 // legacy opcional del v15 (no hay .controls en este layout, se deja seguro)
 document.querySelector('.controls button.primary')?.addEventListener('click',()=>{ alert('El juego ha comenzado!'); });


### PR DESCRIPTION
## Summary
- remove redundant tile click handler so board clicks correctly open property cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0805623c0832488b1b81851b261fc