### PR TITLE
Fix property card display on tile click

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -21,6 +21,7 @@ const MIN_TILE = 48;   // tamaño mínimo de casilla en px
 /* ==== Creación de casilla (estructura v11) ==== */
 function createTileElement(tile, index){
   const el = document.createElement('div'); el.className='tile';
+  el.dataset.index = index;
   const band=document.createElement('div'); band.className='band'; band.style.background=colorFor(tile);
   const head=document.createElement('div'); head.className='head';
   const name=document.createElement('div'); name.className='name'; name.textContent=tile?.name||''; head.appendChild(name);

--- a/index.html
+++ b/index.html
@@ -190,16 +190,6 @@
 
   })();
 
-document.querySelectorAll('.tile').forEach((tile, idx) => {
-  tile.addEventListener('click', (e) => {
-    e.stopPropagation();
-    tile.classList.toggle('active');
-    const ov = document.getElementById('overlay');
-    if (typeof window.showCard === 'function' && ov?.style.display !== 'flex') {
-      window.showCard(idx);
-    }
-  });
-});
 document.querySelectorAll('.badge').forEach(badge=>{
   badge.addEventListener('click',(e)=>{ e.stopPropagation(); badge.classList.toggle('active'); });
 });
@@ -245,10 +235,9 @@ function initGameBindings(){
   board?.addEventListener('click', (e) => {
     const tile = e.target.closest('.tile');
     if (!tile) return;
-    const tiles = Array.from(board.querySelectorAll('.tile'));
-    const idx = tiles.indexOf(tile);
+    const idx = parseInt(tile.dataset.index, 10);
     const ov = document.getElementById('overlay');
-    if (idx > -1 && typeof window.showCard === 'function' && ov?.style.display !== 'flex') {
+    if (!Number.isNaN(idx) && typeof window.showCard === 'function' && ov?.style.display !== 'flex') {
       window.showCard(idx);
     }
   });

--- a/js/v20-part2.js
+++ b/js/v20-part2.js
@@ -21,6 +21,7 @@ const MIN_TILE = 48;   // tamaño mínimo de casilla en px
 /* ==== Creación de casilla (estructura v11) ==== */
 function createTileElement(tile, index){
   const el = document.createElement('div'); el.className='tile';
+  el.dataset.index = index;
   const band=document.createElement('div'); band.className='band'; band.style.background=colorFor(tile);
   const head=document.createElement('div'); head.className='head';
   const name=document.createElement('div'); name.className='name'; name.textContent=tile?.name||''; head.appendChild(name);


### PR DESCRIPTION
## Summary
- Assign each board tile a data-index and rebuild bundle
- Use tile data-index to open property cards from board clicks
- Remove redundant per-tile click handler in HTML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08112ed488324abf97c8e32da83c2