### PR TITLE
feat: add contract drafting to corrupt bank

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
         <button value="debt">Mercado de deuda</button>
         <button value="titulize">Titulizar préstamo</button>
         <button value="options">Derivados de propiedades</button>
+        <button value="contract">Redactar contrato</button>
       </div>
       <div class="row" style="margin-top:8px; justify-content:flex-end">
         <button value="cancel">Cancelar</button>

--- a/js/v20-part6.js
+++ b/js/v20-part6.js
@@ -50,6 +50,26 @@ function showBankMenu(){
   });
 }
 
+async function manageCorruptContract(){
+  if(!window.Roles) return;
+  const existing = Roles.getCorruptContract ? Roles.getCorruptContract() : null;
+  if(existing && existing.text){
+    alert(`Contrato actual:\n${existing.text}\nParticipantes: ${(existing.players||[]).join(', ')}`);
+    const edit = await promptChoice('¿Editar contrato?', [
+      {label:'Editar', value:true},
+      {label:'Salir', value:false}
+    ]);
+    if(!edit) return;
+  }
+  const text = await promptDialog('Texto del contrato:', existing?.text || '');
+  if(text===null) return;
+  const ids = await promptDialog('IDs participantes (separados por comas):', (existing?.players||[]).join(','));
+  if(ids===null) return;
+  const players = ids.split(',').map(s=>s.trim()).filter(Boolean);
+  Roles.setCorruptContract({ text, players });
+  alert('Contrato guardado.');
+}
+
 async function exerciseOption(p){
   if(!p) return;
   const propName = await promptDialog('Nombre propiedad a ejercer:', '');
@@ -276,6 +296,8 @@ async function onLand(p, idx){
             }
           }
         }
+      } else if (opt === 'contract') {
+        await manageCorruptContract();
       }
     } catch(e){}
   }

--- a/js/v22_roles_politics.js
+++ b/js/v22_roles_politics.js
@@ -107,7 +107,8 @@
     fentanyl: { tiles: new Set(), chance: 0.15, fee: 15 },
     statuses: new Map(), // playerId -> { fentanyl?: { tileId, fee, active:true } }
     pendingPayments: [],
-    pendingMoves: []
+    pendingMoves: [],
+    contract: null
   };
 
   // Utilidades
@@ -393,6 +394,15 @@
     return arr;
   };
 
+  R.setCorruptContract = function(data){
+    state.contract = data || null;
+    saveState();
+  };
+
+  R.getCorruptContract = function(){
+    return state.contract || null;
+  };
+
   // —— Florentino: forzar trades + perks en préstamos ——
   R.getFlorentinoUsesLeft = function(player){ const id=(player&&player.id)||player; return state.florentinoUsesLeft.get(id)||0; };
 
@@ -587,7 +597,8 @@
         governmentTurnsLeft: state.governmentTurnsLeft,
         authoritarianTick: state.authoritarianTick,
         pendingPayments: state.pendingPayments||[],
-        pendingMoves: state.pendingMoves||[]
+        pendingMoves: state.pendingMoves||[],
+        contract: state.contract
       };
       localStorage.setItem(LS_KEY, JSON.stringify(plain));
     }catch(e){ /* noop */ }
@@ -612,6 +623,7 @@
       state.pendingPayments = plain.pendingPayments||[];
       state.pendingMoves = plain.pendingMoves||[];
       state.noRentFromWomen = new Set(plain.noRentFromWomen||[]);
+      state.contract = plain.contract || null;
     }catch(e){ /* noop */ }
   }
 
@@ -635,7 +647,8 @@
       statuses: Array.from(state.statuses||new Map()),
       pendingPayments: state.pendingPayments||[],
       pendingMoves: state.pendingMoves||[],
-      noRentFromWomen: Array.from(state.noRentFromWomen||[])
+      noRentFromWomen: Array.from(state.noRentFromWomen||[]),
+      contract: state.contract||null
     };
   };
   R.importState = function(obj){
@@ -657,6 +670,7 @@
       state.pendingPayments = obj.pendingPayments||[];
       state.pendingMoves = obj.pendingMoves||[];
       state.noRentFromWomen = new Set(obj.noRentFromWomen||[]);
+      state.contract = obj.contract || null;
       saveState(); uiUpdate();
       return true;
     }catch(e){ return false; }


### PR DESCRIPTION
## Summary
- allow players to draft and store a contract from the corrupt bank menu
- persist contract details in Roles state with getter/setter helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0833da03c8324b2432f5fd9cbfa72