### PR TITLE
Gracefully handle invalid indices in showCard

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -687,6 +687,10 @@ function showCard(tileIndex, {canAuction=false}={}) {
   }
 
   const t = TILES[tileIndex];
+  if (!t) {
+    if (overlay) overlay.style.display = 'none';
+    return;
+  }
   const st = window.state;
   if (st) st.pendingTile = tileIndex;
   // Título por defecto

--- a/js/v20-part3.js
+++ b/js/v20-part3.js
@@ -451,6 +451,10 @@ function showCard(tileIndex, {canAuction=false}={}) {
   }
 
   const t = TILES[tileIndex];
+  if (!t) {
+    if (overlay) overlay.style.display = 'none';
+    return;
+  }
   const st = window.state;
   if (st) st.pendingTile = tileIndex;
   // Título por defecto

--- a/tests/showCardInvalid.test.js
+++ b/tests/showCardInvalid.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+test('showCard handles invalid tile index gracefully', () => {
+  // Minimal window/document stubs required by the module
+  global.window = {
+    addEventListener: () => {},
+    dispatchEvent: () => {}
+  };
+  global.document = {
+    addEventListener: () => {},
+    getElementById: () => null
+  };
+
+  // Load the module which defines window.showCard
+  require('../js/v20-part3.js');
+
+  assert.doesNotThrow(() => {
+    window.showCard(9999);
+  });
+
+  // cleanup globals to not affect other tests
+  delete global.window;
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- Guard `showCard` against invalid tile indices to avoid crashes
- Ensure bundled script includes the same guard
- Add regression test verifying `showCard` handles invalid indices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a084bc4c1083248ec31514ea4a0e16